### PR TITLE
[FE] 이슈 목록 화면 UI 구성

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -1078,6 +1078,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",
@@ -6215,6 +6223,12 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
+    },
+    "react-timeago": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-timeago/-/react-timeago-4.4.0.tgz",
+      "integrity": "sha512-Zj8RchTqZEH27LAANemzMR2RpotbP2aMd+UIajfYMZ9KW4dMcViUVKzC7YmqfiqlFfz8B0bjDw2xUBjmcxDngA==",
+      "dev": true
     },
     "react-transition-group": {
       "version": "4.4.1",

--- a/FE/package.json
+++ b/FE/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.10.1",
+    "@material-ui/icons": "^4.9.1",
     "axios": "^0.19.2",
     "clean-webpack-plugin": "^3.0.0",
     "react": "^16.13.1",

--- a/FE/package.json
+++ b/FE/package.json
@@ -33,6 +33,7 @@
     "file-loader": "^6.0.0",
     "html-webpack-plugin": "^4.3.0",
     "moment": "^2.26.0",
+    "react-timeago": "^4.4.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.11.0",

--- a/FE/src/components/NavigationButton/NavigationButton.jsx
+++ b/FE/src/components/NavigationButton/NavigationButton.jsx
@@ -1,7 +1,38 @@
 import React from "react";
+import styled from "styled-components";
+import LabelIcon from "@material-ui/icons/Label";
+import EventNoteIcon from "@material-ui/icons/EventNote";
+
+import Button from "@Style/Button";
 
 const NavigationButton = () => {
-  return <div></div>;
+  return (
+    <Wrapper>
+      <LeftButton color="gray" backgroudColor="white">
+        <LabelIcon fontSize="small" />
+        Labels
+      </LeftButton>
+      <RightButton color="gray" backgroudColor="white">
+        <EventNoteIcon fontSize="small" />
+        Milestones
+      </RightButton>
+    </Wrapper>
+  );
 };
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const LeftButton = styled(Button)`
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+`;
+
+const RightButton = styled(Button)`
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+`;
 
 export default NavigationButton;

--- a/FE/src/style/Button.js
+++ b/FE/src/style/Button.js
@@ -4,13 +4,19 @@ const Button = styled.button`
   background-color: ${({ theme, backgroudColor }) =>
     theme.colors[backgroudColor] || theme.colors.green};
   color: ${({ theme, color }) => theme.colors[color] || theme.colors.white};
-  font-size: ${({ theme, fontSize }) => theme.fontSizes[fontSize]};
+  font-size: ${({ theme, fontSize }) => theme.fontSizes[fontSize] || theme.fontSizes.md};
+  font-weight: ${({ bold }) => (bold ? "bold" : "normal")};
   pointer-events: ${({ disabled }) => (disabled ? "none" : "auto")};
   cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
   opacity: ${({ disabled }) => (disabled ? 0.3 : 1)};
-  border-radius: 10px;
-  border: none;
+  border-radius: 5px;
+  border: 1px solid ${({ theme }) => theme.colors.lightGray};
   text-align: center;
+  padding: ${({ paddingSize }) => (paddingSize ? paddingSize : "10px 15px")};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 `;
 
 export default Button;

--- a/FE/src/style/theme.js
+++ b/FE/src/style/theme.js
@@ -4,6 +4,7 @@ const colors = {
   green: "#00b8a9",
   gray: "#393e46",
   lightGray: "#eee",
+  frenchGray: "#fafbfc",
   black: "#222831",
   red: "#fc5185",
   white: "#fff",

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -42,22 +42,56 @@ const IssueList = () => {
   );
 };
 
-const Wrapper = styled.div``;
+const Wrapper = styled.div`
+  display: flex;
+  padding: 15px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.lightGray};
+`;
 
-const CheckboxWrapper = styled.div``;
+const CheckboxWrapper = styled.div`
+  padding-right: 10px;
+`;
 
 const Checkbox = styled.input.attrs({ type: "checkbox" })``;
 
-const OpenIcon = styled(ErrorOutlineIcon)``;
+const OpenIcon = styled(ErrorOutlineIcon)`
+  color: ${({ theme }) => theme.colors.green};
+  margin-right: 15px;
+`;
 
 const IssueWrapper = styled.div``;
 
-const Title = styled.div``;
+const Title = styled.div`
+  margin-bottom: 5px;
+`;
 
-const Badge = styled.span``;
+const Badge = styled.span`
+  background-color: ${({ theme }) => theme.colors.green};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 2px;
+  height: 20px;
+  padding: 0.15em 4px;
+  margin-left: 4px;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  line-height: ${({ theme }) => theme.fontSizes.sm};
+`;
 
-const Info = styled.div``;
+const Info = styled.div`
+  display: flex;
+  align-items: center;
+  span {
+    margin-right: 5px;
+  }
+`;
 
-const Milestone = styled.span``;
+const Milestone = styled.span`
+  display: flex;
+  align-items: center;
+  &:hover {
+    color: ${({ theme }) => theme.colors.lightGray};
+    cursor: pointer;
+  }
+`;
 
 export default IssueList;

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import styled from "styled-components";
+import ErrorOutlineIcon from "@material-ui/icons/ErrorOutline";
+import EventNoteIcon from "@material-ui/icons/EventNote";
+import TimeAgo from "react-timeago";
+import koreaStrings from "react-timeago/lib/language-strings/ko";
+import buildFormatter from "react-timeago/lib/formatters/buildFormatter";
+
+import Text from "@Style/Text";
+
+const formatter = buildFormatter(koreaStrings);
+
+const IssueList = () => {
+  return (
+    <Wrapper>
+      <CheckboxWrapper>
+        <Checkbox />
+      </CheckboxWrapper>
+      <OpenIcon />
+      <IssueWrapper>
+        <Title>
+          <Text fontWeight="bold" as="a">
+            목록 보기 구현
+          </Text>
+          <Badge>bug</Badge>
+        </Title>
+        <Info>
+          <Text fontSize="sm">#2 opened</Text>
+          <Text fontSize="sm">
+            <TimeAgo date="May 25, 2020" formatter={formatter} />{" "}
+          </Text>
+          <Text fontSize="sm">by choisohyun</Text>
+          <Text fontSize="sm">
+            <Milestone>
+              <EventNoteIcon style={{ fontSize: 15 }} />
+              스프린트2
+            </Milestone>
+          </Text>
+        </Info>
+      </IssueWrapper>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div``;
+
+const CheckboxWrapper = styled.div``;
+
+const Checkbox = styled.input.attrs({ type: "checkbox" })``;
+
+const OpenIcon = styled(ErrorOutlineIcon)``;
+
+const IssueWrapper = styled.div``;
+
+const Title = styled.div``;
+
+const Badge = styled.span``;
+
+const Info = styled.div``;
+
+const Milestone = styled.span``;
+
+export default IssueList;

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -45,26 +45,88 @@ const IssueListPage = () => {
   );
 };
 
-const Header = styled.header``;
+const Header = styled.header`
+  width: 100%;
+  height: 80px;
+  background-color: ${({ theme }) => theme.colors.black};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 40px;
+`;
 
-const HeaderIcon = styled(SubjectIcon)``;
+const HeaderIcon = styled(SubjectIcon)`
+  color: ${({ theme }) => theme.colors.lightGray};
+  margin-right: 5px;
+`;
 
-const NavBarWrap = styled.nav``;
+const NavBarWrap = styled.nav`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 40px;
+`;
 
-const NavBar = styled.nav``;
+const NavBar = styled.nav`
+  width: 65%;
+  height: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 
-const SearchBarWrapper = styled.div``;
+const SearchBarWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  width: 55%;
+`;
 
-const SearchBar = styled.form``;
+const SearchBar = styled.form`
+  position: relative;
+  height: 100%;
+  width: 100%;
+`;
 
-const SearchInput = styled.input``;
+const SearchInput = styled.input`
+  padding-left: 30px;
+  background-color: ${({ theme }) => theme.colors.frenchGray};
+  color: ${({ theme }) => theme.colors.gray};
+  border-radius: 5px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border: 1px solid ${({ theme }) => theme.colors.lightGray};
+  outline: none;
+  height: inherit;
+  width: inherit;
+`;
 
-const SearchInputIcon = styled(SearchIcon)``;
+const SearchInputIcon = styled(SearchIcon)`
+  position: absolute;
+  top: 9px;
+  left: 8px;
+  display: block;
+  color: ${({ theme }) => theme.colors.lightGray};
+  text-align: center;
+  pointer-events: none;
+`;
 
-const IssueListWrapper = styled.div``;
+const IssueListWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 100px;
+`;
 
-const IssueList = styled.div``;
+const IssueList = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.lightGray};
+  border-radius: 5px;
+  width: 65%;
+`;
 
-const IssueHeader = styled.div``;
+const IssueHeader = styled.div`
+  background-color: ${({ theme }) => theme.colors.frenchGray};
+  height: 50px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.lightGray};
+`;
 
 export default IssueListPage;

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -1,7 +1,70 @@
 import React from "react";
+import styled from "styled-components";
+import SubjectIcon from "@material-ui/icons/Subject";
+import SearchIcon from "@material-ui/icons/Search";
+import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
+
+import NavigationButton from "@NavigationButton/NavigationButton";
+import Issue from "@IssueListPage/Issue/Issue";
+import Text from "@Style/Text";
+import Button from "@Style/Button";
 
 const IssueListPage = () => {
-  return <div></div>;
+  return (
+    <>
+      <Header>
+        <HeaderIcon />
+        <Text color="white" fontWeight="bold" as="h2">
+          ISSUES
+        </Text>
+      </Header>
+      <NavBarWrap>
+        <NavBar>
+          <SearchBarWrapper>
+            <Button backgroudColor="frenchGray" color="black">
+              Filters
+              <ArrowDropDownIcon />
+            </Button>
+            <SearchBar>
+              <SearchInput placeholder="Search all issues" />
+              <SearchInputIcon />
+            </SearchBar>
+          </SearchBarWrapper>
+          <NavigationButton />
+          <Button>New Issue</Button>
+        </NavBar>
+      </NavBarWrap>
+      <IssueListWrapper>
+        <IssueList>
+          <IssueHeader></IssueHeader>
+          <Issue></Issue>
+          <Issue></Issue>
+        </IssueList>
+      </IssueListWrapper>
+    </>
+  );
 };
+
+const Header = styled.header``;
+
+const HeaderIcon = styled(SubjectIcon)``;
+
+const NavBarWrap = styled.nav``;
+
+const NavBar = styled.nav``;
+
+const SearchBarWrapper = styled.div``;
+
+const SearchBar = styled.form``;
+
+const SearchInput = styled.input``;
+
+const SearchInputIcon = styled(SearchIcon)``;
+
+const IssueListWrapper = styled.div``;
+
+const IssueList = styled.div``;
+
+const IssueHeader = styled.div``;
 
 export default IssueListPage;


### PR DESCRIPTION
### 구현한 내용

<img width="991" alt="Screen Shot 2020-06-10 at 0 49 25" src="https://user-images.githubusercontent.com/30427711/84170094-44016a00-aab4-11ea-99d9-734c0714d8a0.png">

- 이슈 목록 화면 UI 구성하였습니다.
- react-timeago 라이브러리 사용하여 현재 시간 기준으로 얼마나 떨어져 있는지 표시했습니다
(대상 날짜는 임시로 하드코딩하였습니다.)
- 재사용 컴포넌트인 NavigationButton을 만들었습니다.
- 재사용 스타일인 Button은 사용에 맞게 여러 스타일 추가했습니다.
- 더 연한 색의 gray를 사용하기 위해 theme에 색상 추가했습니다.
- 이슈 필터 부분은 미구현 상태입니다.

Close #3 
