### PR TITLE
[FE] 이슈 상세 페이지(코멘트 / 필터버튼리스트)

### DIFF
--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -5,6 +5,7 @@ import engStrings from "react-timeago/lib/language-strings/en";
 import buildFormatter from "react-timeago/lib/formatters/buildFormatter";
 
 import Text from "@Style/Text";
+import Badge from "@Style/Badge";
 
 const formatter = buildFormatter(engStrings);
 
@@ -22,13 +23,16 @@ const CommentViewBox = ({ owner }) => {
               </Text>
             </CommentText>
             <CommentAction>
-              {owner && <Badge>Owner</Badge>}
+              {owner && (
+                <Badge backgroundColor="babyblue" borderColor="gray3" color="gray4">
+                  Owner
+                </Badge>
+              )}
               <Text color="gray4">Edit</Text>
               <Text color="gray4">Delete</Text>
             </CommentAction>
           </CommentHeader>
-          <CommentContent>
-          </CommentContent>
+          <CommentContent></CommentContent>
         </CommentGroup>
       </Wrapper>
     </>
@@ -115,15 +119,6 @@ const CommentAction = styled.div`
   ${Text} {
     margin-left: 10px;
   }
-`;
-
-const Badge = styled.span`
-  border: 1px solid ${({ theme }) => theme.colors.gray3};
-  font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-weight: ${({ theme }) => theme.fontWeights.bold};
-  color: ${({ theme }) => theme.colors.gray4};
-  padding: 3px;
-  border-radius: 3px;
 `;
 
 export default CommentViewBox;

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -1,7 +1,55 @@
 import React from "react";
+import styled from "styled-components";
 
-const CommentViewBox = () => {
-  return <div></div>;
+import Text from "@Style/Text";
+const CommentViewBox = ({ owner }) => {
+  return (
+    <>
+      <Wrapper>
+        <Avatar src="https://avatars1.githubusercontent.com/u/30427711?s=88&u=0f6f414055ea0bec267856e35e8902b9f728fe1a&v=4"></Avatar>
+        <CommentGroup>
+          <CommentHeader owner={owner ? true : false}>
+            <CommentText>
+              <Text fontWeight="extraBold">choisohyun</Text>
+              <Text color="gray4">
+              </Text>
+            </CommentText>
+            <CommentAction>
+              {owner && <Badge>Owner</Badge>}
+              <Text color="gray4">Edit</Text>
+              <Text color="gray4">Delete</Text>
+            </CommentAction>
+          </CommentHeader>
+          <CommentContent>
+          </CommentContent>
+        </CommentGroup>
+      </Wrapper>
+    </>
+  );
 };
+
+const Wrapper = styled.div`
+`;
+
+const Avatar = styled.img`
+`;
+
+const CommentGroup = styled.div`
+`;
+
+const CommentHeader = styled.div`
+`;
+
+const CommentContent = styled.div`
+`;
+
+const CommentText = styled.div`
+`;
+
+const CommentAction = styled.div`
+`;
+
+const Badge = styled.span`
+`;
 
 export default CommentViewBox;

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -29,27 +29,94 @@ const CommentViewBox = ({ owner }) => {
 };
 
 const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  padding: 16px 0;
+  margin: 0 16px;
+  &::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    display: block;
+    width: 2px;
+    content: "";
+    background-color: ${({ theme }) => theme.colors.gray2};
+  }
 `;
 
 const Avatar = styled.img`
+  position: absolute;
+  left: -72px;
+  z-index: 1;
+  width: 40px;
+  height: 40px;
+  border-radius: 3px;
 `;
 
 const CommentGroup = styled.div`
+  width: 100%;
+  z-index: 2;
+  background-color: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colors.gray4};
+  border: 1px solid ${({ theme }) => theme.colors.gray2};
+  border-color: ${({ theme }) => theme.colors.skyblue};
+  flex: auto;
+  border-radius: 3px;
+  margin-left: -16px;
+  &::before {
+    color: ${({ theme }) => theme.colors.skyblue};
+    position: absolute;
+    top: 28px;
+    left: -28px;
+    content: "◀︎";
+  }
 `;
 
 const CommentHeader = styled.div`
+  width: 100%;
+  height: 40px;
+  background-color: ${({ theme, owner }) => (owner ? theme.colors.babyblue : theme.colors.gray2)};
+  border-bottom-color: #c0d3eb;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 16px;
+  padding-left: 16px;
+  color: #586069;
+  flex-direction: row;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray3};
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
 `;
 
 const CommentContent = styled.div`
+  width: 100%;
+  height: 200px;
+  padding: 15px;
+  overflow: visible;
 `;
 
 const CommentText = styled.div`
+  display: flex;
+  ${Text} {
+    margin-right: 10px;
+  }
 `;
 
 const CommentAction = styled.div`
+  ${Text} {
+    margin-left: 10px;
+  }
 `;
 
 const Badge = styled.span`
+  border: 1px solid ${({ theme }) => theme.colors.gray3};
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  color: ${({ theme }) => theme.colors.gray4};
+  padding: 3px;
+  border-radius: 3px;
 `;
 
 export default CommentViewBox;

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -1,7 +1,13 @@
 import React from "react";
 import styled from "styled-components";
+import TimeAgo from "react-timeago";
+import engStrings from "react-timeago/lib/language-strings/en";
+import buildFormatter from "react-timeago/lib/formatters/buildFormatter";
 
 import Text from "@Style/Text";
+
+const formatter = buildFormatter(engStrings);
+
 const CommentViewBox = ({ owner }) => {
   return (
     <>
@@ -12,6 +18,7 @@ const CommentViewBox = ({ owner }) => {
             <CommentText>
               <Text fontWeight="extraBold">choisohyun</Text>
               <Text color="gray4">
+                commented <TimeAgo date="May 25, 2020" formatter={formatter} />
               </Text>
             </CommentText>
             <CommentAction>

--- a/FE/src/style/Badge.js
+++ b/FE/src/style/Badge.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+const Badge = styled.span`
+  background-color: ${({ theme, backgroundColor }) => theme.colors[backgroundColor] || backgroundColor || theme.colors.green};
+  color: ${({ theme, color }) => theme.colors[color] || theme.colors.white};
+  border: ${({ theme, borderColor }) => (borderColor ? `1px solid ${theme.colors[borderColor]}` : "")};
+  border-radius: 2px;
+  height: 20px;
+  padding: 0.15em 4px;
+  margin-left: 4px;
+  font-size: ${({ theme }) => theme.fontSizes.sm};
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  line-height: ${({ theme }) => theme.fontSizes.sm};
+`;
+
+export default Badge;

--- a/FE/src/style/theme.js
+++ b/FE/src/style/theme.js
@@ -1,6 +1,7 @@
 const colors = {
   blue: "#00adb5",
-  skyblue: "#cbf1f5",
+  skyblue: "#c0d3eb",
+  babyblue: "#f1f8ff",
   green: "#00b8a9",
   gray1: "#fafbfc",
   gray2: "#eee",

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -1,7 +1,44 @@
 import React from "react";
+import styled from "styled-components";
+
+import FilterVerticalList from "@FilterButton/FilterVerticalList";
+import Header from "@Header/Header";
+import CommentViewBox from "@CommentViewBox/CommentViewBox";
 
 const IssueDetailPage = () => {
-  return <div></div>;
+  return (
+    <>
+      <Header />
+      <ContentWrapper>
+        <Content>
+          <CommentViewBoxWrapper>
+            <CommentViewBox owner />
+            <CommentViewBox />
+            <CommentViewBox />
+          </CommentViewBoxWrapper>
+          <FilterVerticalList />
+        </Content>
+      </ContentWrapper>
+    </>
+  );
 };
+
+const ContentWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const Content = styled.div`
+  width: 65%;
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid ${({ theme }) => theme.colors.gray2};
+  margin-top: 16px;
+  padding-left: 72px;
+`;
+
+const CommentViewBoxWrapper = styled.div`
+  width: 75%;
+`;
 
 export default IssueDetailPage;

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -7,6 +7,7 @@ import koreaStrings from "react-timeago/lib/language-strings/ko";
 import buildFormatter from "react-timeago/lib/formatters/buildFormatter";
 
 import Text from "@Style/Text";
+import Badge from "@Style/Badge";
 
 const formatter = buildFormatter(koreaStrings);
 
@@ -65,18 +66,6 @@ const IssueWrapper = styled.div``;
 
 const Title = styled.div`
   margin-bottom: 5px;
-`;
-
-const Badge = styled.span`
-  background-color: ${({ theme }) => theme.colors.green};
-  color: ${({ theme }) => theme.colors.white};
-  border-radius: 2px;
-  height: 20px;
-  padding: 0.15em 4px;
-  margin-left: 4px;
-  font-size: ${({ theme }) => theme.fontSizes.sm};
-  font-weight: ${({ theme }) => theme.fontWeights.bold};
-  line-height: ${({ theme }) => theme.fontSizes.sm};
 `;
 
 const Info = styled.div`

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -10,7 +10,7 @@ import Text from "@Style/Text";
 
 const formatter = buildFormatter(koreaStrings);
 
-const IssueList = () => {
+const Issue = (props) => {
   return (
     <>
       <Wrapper>
@@ -19,7 +19,7 @@ const IssueList = () => {
         </CheckboxWrapper>
         <OpenIcon />
         <IssueWrapper>
-          <Title>
+          <Title onClick={() => props.history.push(`/IssueDetailPage`)}>
             <Text fontWeight="bold" as="a">
               목록 보기 구현
             </Text>
@@ -96,4 +96,4 @@ const Milestone = styled.span`
   }
 `;
 
-export default IssueList;
+export default Issue;

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -28,7 +28,7 @@ const Issue = (props) => {
           <Info>
             <Text fontSize="sm">#2 opened</Text>
             <Text fontSize="sm">
-              <TimeAgo date="May 25, 2020" formatter={formatter} />{" "}
+              <TimeAgo date="May 25, 2020" formatter={formatter} />
             </Text>
             <Text fontSize="sm">by choisohyun</Text>
             <Text fontSize="sm">

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -14,7 +14,7 @@ import Table from "@Table/Table";
 const IssueListPage = (props) => {
   const issueList = (
     <>
-      <Issue></Issue>
+      <Issue history={props.history}></Issue>
       <Issue></Issue>
     </>
   );


### PR DESCRIPTION
### 구현한 내용

<img width="1119" alt="Screen Shot 2020-06-11 at 18 48 31" src="https://user-images.githubusercontent.com/30427711/84371127-277c4380-ac14-11ea-8d8f-342fcde92086.png">

- 코멘트 재사용 컴포넌트 작성
- owner 여부에 따라 뱃지와 색이 다르게 보이도록 함
- 타이틀과 코멘트는 미구현 상태

Close #5 

