### PR TITLE
[FE] 새로운 마일스톤 쓰기 페이지

### DIFF
--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -27,7 +27,7 @@ const App = () => {
             <Route path="/IssueDetailPage" exact component={IssueDetailPage} />
             <Route path="/LabelListPage" exact component={LabelListPage} />
             <Route path="/MilestonePage" exact component={MilestonePage} />
-            <Route path="/CreateMilestonePage" exact component={CreateMilestonePage} />
+            <Route path="/CreateMilestonePage/:state" component={CreateMilestonePage} />
             <Route component={ErrorPage} />
           </Switch>
         </Router>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -68,7 +68,7 @@ const CommentGroup = styled.div`
   z-index: 2;
   background-color: ${({ theme }) => theme.colors.white};
   color: ${({ theme }) => theme.colors.gray4};
-  border: 1px solid ${({ theme }) => theme.colors.gray3};
+  border: 1px solid ${({ theme }) => theme.colors.gray2};
   flex: auto;
   border-radius: 3px;
   margin-left: -16px;
@@ -86,14 +86,14 @@ const Title = styled.input`
   margin: 5px;
   padding: 5px 5px 5px 10px;
   width: -webkit-fill-available;
-  border: 1px solid ${({ theme }) => theme.colors.gray3};
+  border: 1px solid ${({ theme }) => theme.colors.gray2};
   font-size: ${({ theme }) => theme.fontSizes.lg};
 `;
 
 const CommentContent = styled.div`
   width: 100%;
   padding: 10px;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray3};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray2};
   overflow: visible;
 `;
 
@@ -104,14 +104,14 @@ const ButtonTab = styled.div`
 
 const WriteButton = styled.button`
   padding: 5px 10px;
-  border: 1px ${(props) => (props.isRawOpen ? "solid" : "none")} ${({ theme }) => theme.colors.gray3};
+  border: 1px ${(props) => (props.isRawOpen ? "solid" : "none")} ${({ theme }) => theme.colors.gray2};
   border-bottom: none;
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
 const PreviewButton = styled.button`
   padding: 5px 10px;
-  border: 1px ${(props) => (props.isRawOpen ? "none" : "solid")} ${({ theme }) => theme.colors.gray3};
+  border: 1px ${(props) => (props.isRawOpen ? "none" : "solid")} ${({ theme }) => theme.colors.gray2};
   border-bottom: none;
   background-color: ${({ theme }) => theme.colors.white};
 `;
@@ -119,7 +119,7 @@ const PreviewButton = styled.button`
 const RawContent = styled.textarea`
   padding: 5px;
   background-color: ${({ theme }) => theme.colors.gray1};
-  border: 1px solid ${({ theme }) => theme.colors.gray3};
+  border: 1px solid ${({ theme }) => theme.colors.gray2};
   display: ${(props) => (props.isRawOpen ? "block" : "none")};
   width: -webkit-fill-available;
   min-height: 200px;

--- a/FE/src/components/InputBox/PersonalInputBox.jsx
+++ b/FE/src/components/InputBox/PersonalInputBox.jsx
@@ -3,12 +3,16 @@ import styled from "styled-components";
 
 import Text from "@Style/Text";
 
-const PersonalInputBox = ({ title, widthSize, value }) => {
+const PersonalInputBox = ({ title, widthSize, value, backgroundColor, placeholder }) => {
   return (
     <>
       <Wrap>
         <Text children={title} fontWeight="bold" />
-        {value ? <InputBox type="text" widthSize={widthSize} value={value} readOnly /> : <InputBox type="text" widthSize={widthSize} />}
+        {value ? (
+          <InputBox type="text" widthSize={widthSize} value={value} backgroundColor={backgroundColor} placeholder={placeholder} readOnly />
+        ) : (
+          <InputBox type="text" widthSize={widthSize} backgroundColor={backgroundColor} placeholder={placeholder} />
+        )}
       </Wrap>
     </>
   );
@@ -28,6 +32,7 @@ const InputBox = styled.input`
   border-radius: 5px;
   border: 1px solid ${({ theme }) => theme.colors.gray2};
   width: ${({ widthSize }) => (widthSize ? widthSize : "")};
+  background-color: ${({ theme, backgroundColor }) => (backgroundColor ? theme.colors[backgroundColor] : "")};
 `;
 
 export default PersonalInputBox;

--- a/FE/src/components/NavigationButton/NavigationButton.jsx
+++ b/FE/src/components/NavigationButton/NavigationButton.jsx
@@ -20,7 +20,7 @@ const NavigationButton = (props) => {
         <RightButton
           color={props.isMilestone ? "white" : "gray4"}
           backgroundColor={props.isMilestone ? "blue" : "white"}
-          onClick={() => props.history.push(`/MileStonePage`)}
+          onClick={() => props.history.push(`/MilestonePage`)}
         >
           <EventNoteIcon fontSize="small" />
           Milestones

--- a/FE/src/views/CreateMilestonePage/CreateMilestonePage.jsx
+++ b/FE/src/views/CreateMilestonePage/CreateMilestonePage.jsx
@@ -1,7 +1,104 @@
 import React from "react";
+import styled from "styled-components";
 
-const CreateMilestonePage = () => {
-  return <div></div>;
+import Button from "@Style/Button";
+import Text from "@Style/Text";
+
+import Header from "@Header/Header";
+import NavigationButton from "@NavigationButton/NavigationButton";
+import PersonalInputBox from "@InputBox/PersonalInputBox";
+import DatePickers from "./DatePickers";
+
+const CreateMilestonePage = (props) => {
+  const isEdit = props.match.params.state === "isEdit";
+  return (
+    <>
+      <Header history={props.history} />
+      <Wrapper>
+        <ContentWrapper>
+          <InfoWrapper>
+            {isEdit ? (
+              <NavigationButton history={props.history} isMilestone />
+            ) : (
+              <>
+                <Text fontSize="xl" fontWeight="bold">
+                  New milestone
+                </Text>
+                <Text>Create a new milestone to help organize your issues and pull requests. Learn more about milestones and issues.</Text>
+              </>
+            )}
+          </InfoWrapper>
+          <Content>
+            <PersonalInputBox title="Title" widthSize="50%" backgroundColor="gray1" placeholder="Title" value={props.title}></PersonalInputBox>
+            <Text fontWeight="bold">Due date (optional)</Text>
+            <DatePickers defaultValue={props.date || "연도-월-일"}></DatePickers>
+            <Text fontWeight="bold">Description (optional)</Text>
+            <DescriptionBox value={props.description} />
+          </Content>
+          <ButtonWrapper>
+            {isEdit ? (
+              <>
+                <Button backgroundColor="gray1" color="black" onClick={() => props.history.push(`/MilestonePage`)}>
+                  Cancel
+                </Button>
+                <Button backgroundColor="gray1" color="black" onClick={() => props.history.push(`/MilestonePage`)}>
+                  Close milestone
+                </Button>
+                <Button onClick={() => props.history.push(`/MilestonePage`)}>Save changes</Button>
+              </>
+            ) : (
+              <Button onClick={() => props.history.push(`/MilestonePage`)}>Create milestone</Button>
+            )}
+          </ButtonWrapper>
+        </ContentWrapper>
+      </Wrapper>
+    </>
+  );
 };
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 100px;
+`;
+
+const ContentWrapper = styled.div`
+  width: 65%;
+  flex-direction: column;
+`;
+
+const InfoWrapper = styled.div`
+  display: flex;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray2};
+  flex-direction: column;
+  padding: 20px 0;
+  align-items: end;
+`;
+
+const Content = styled.div`
+  display: flex;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray2};
+  flex-direction: column;
+  padding: 20px 0;
+`;
+
+const DescriptionBox = styled.textarea`
+  margin-top: 5px;
+  min-height: 120px;
+  max-height: 300px;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid ${({ theme }) => theme.colors.gray2};
+  width: 80%;
+  background-color: ${({ theme }) => theme.colors.gray1};
+  resize: vertical;
+  overflow-y: scroll;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding: 20px 0;
+`;
 
 export default CreateMilestonePage;

--- a/FE/src/views/CreateMilestonePage/DatePickers.jsx
+++ b/FE/src/views/CreateMilestonePage/DatePickers.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import TextField from "@material-ui/core/TextField";
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    display: "flex",
+    flexWrap: "wrap",
+    margin: "5px 0 20px 0",
+  },
+  inputBase: {
+    backgroundColor: "red",
+    padding: 0,
+  },
+  textField: {
+    width: "50%",
+    backgroundColor: "#fafbfc",
+    border: "1px solid #eee",
+    padding: 10,
+    borderRadius: 5,
+  },
+}));
+
+const DatePickers = ({ defaultValue }) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <form className={classes.container} noValidate>
+        <TextField
+          id="date"
+          type="date"
+          defaultValue={defaultValue}
+          className={classes.textField}
+          InputLabelProps={{
+            shrink: true,
+          }}
+          inputProps={{
+            style: { padding: 0, fontSize: "13px" },
+          }}
+          InputProps={{ disableUnderline: true }}
+        />
+      </form>
+    </>
+  );
+};
+
+export default DatePickers;

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -63,7 +63,7 @@ const Contents = styled.form`
   padding: 16px;
   border-radius: 3px;
   background-color: ${({ theme }) => theme.colors.gray1};
-  border: 1px solid ${({ theme }) => theme.colors.gray3};
+  border: 1px solid ${({ theme }) => theme.colors.gray2};
 `;
 
 const BadgeWrapper = styled.div`


### PR DESCRIPTION
### 구현한 내용
![issue_tracker_create_milestone_page_1](https://user-images.githubusercontent.com/45891045/84488764-a25c6180-acdb-11ea-9d7a-5225734562ed.PNG)
![issue_tracker_create_milestone_page_2](https://user-images.githubusercontent.com/45891045/84488768-a38d8e80-acdb-11ea-8194-0983647cf007.PNG)

- url 파라미터로 넘어온 state에 따라 새로운 마일스톤 쓰기와 마일스톤 편집하기로 구분
- 모든 버튼은 클릭시 마일스톤 목록 화면으로 연결
- 달력은 material ui 의 datepickers를 활용

