### PR TITLE
[FE] 마일스톤 목록 페이지 UI 작성

### DIFF
--- a/FE/src/style/Text.js
+++ b/FE/src/style/Text.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 const Text = styled.span`
   display: inline-block;
-  color: ${({ theme, color }) => theme.colors[color] || theme.colors.black};
+  color: ${({ theme, color }) => theme.colors[color] || color || theme.colors.black};
   font-size: ${({ theme, fontSize }) => theme.fontSizes[fontSize] || theme.fontSizes.md};
   font-weight: ${({ theme, fontWeight }) => theme.fontWeights[fontWeight] || theme.fontWeights.regular};
   line-height: ${({ lineHeight }) => lineHeight};

--- a/FE/src/views/MilestonePage/Milestone/Milestone.jsx
+++ b/FE/src/views/MilestonePage/Milestone/Milestone.jsx
@@ -17,7 +17,33 @@ const Milestone = ({ title, date, description }) => {
           </DueDateWrapper>
           <Text color="gray3">{description}</Text>
         </TitleWrapper>
-        <ProgressWrapper></ProgressWrapper>
+        <ProgressWrapper>
+          <ProgressBar>
+            <Progress></Progress>
+          </ProgressBar>
+          <StatusBar>
+            <Text fontSize="sm" fontWeight="semiBold">
+              <Text>90%</Text> complete
+            </Text>
+            <Text fontSize="sm" fontWeight="semiBold">
+              <Text>3</Text> open
+            </Text>
+            <Text fontSize="sm" fontWeight="semiBold">
+              <Text>28</Text> closed
+            </Text>
+          </StatusBar>
+          <AdminWrapper>
+            <Text color="blue" fontSize="sm">
+              Edit
+            </Text>
+            <Text color="blue" fontSize="sm">
+              Close
+            </Text>
+            <Text color="red" fontSize="sm">
+              Delete
+            </Text>
+          </AdminWrapper>
+        </ProgressWrapper>
       </Wrapper>
     </>
   );
@@ -43,6 +69,38 @@ const DueDateWrapper = styled(Text)`
   margin: 10px 0;
 `;
 
-const ProgressWrapper = styled.div``;
+const ProgressWrapper = styled.div`
+  min-height: inherit;
+  width: 400px;
+  padding: 15px 20px;
+`;
+
+const ProgressBar = styled.div`
+  margin-top: 7px;
+  margin-bottom: 12px;
+  height: 10px;
+  background-color: ${({ theme }) => theme.colors.gray3};
+  border-radius: 3px;
+`;
+
+const Progress = styled.div`
+  width: 50%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.green};
+  border-radius: 3px;
+`;
+
+const StatusBar = styled.div`
+  ${Text} + ${Text} {
+    margin-left: 15px;
+  }
+`;
+
+const AdminWrapper = styled.div`
+  margin-top: 8px;
+  ${Text} + ${Text} {
+    margin-left: 15px;
+  }
+`;
 
 export default Milestone;

--- a/FE/src/views/MilestonePage/Milestone/Milestone.jsx
+++ b/FE/src/views/MilestonePage/Milestone/Milestone.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import styled from "styled-components";
+import CalendarTodayIcon from "@material-ui/icons/CalendarToday";
+
+import Text from "@Style/Text";
+
+const Milestone = ({ title, date, description }) => {
+  return (
+    <>
+      <Wrapper>
+        <TitleWrapper>
+          <Text fontSize="xl" as="a">
+            {title}
+          </Text>
+          <DueDateWrapper color="gray4">
+            <CalendarTodayIcon fontSize="small" /> Due by {date}
+          </DueDateWrapper>
+          <Text color="gray3">{description}</Text>
+        </TitleWrapper>
+        <ProgressWrapper></ProgressWrapper>
+      </Wrapper>
+    </>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  min-height: 100px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray2};
+`;
+
+const TitleWrapper = styled.div`
+  width: 500px;
+  min-height: inherit;
+  display: flex;
+  flex-direction: column;
+  padding: 15px 20px;
+`;
+
+const DueDateWrapper = styled(Text)`
+  display: flex;
+  align-items: center;
+  margin: 10px 0;
+`;
+
+const ProgressWrapper = styled.div``;
+
+export default Milestone;

--- a/FE/src/views/MilestonePage/Milestone/Milestone.jsx
+++ b/FE/src/views/MilestonePage/Milestone/Milestone.jsx
@@ -4,7 +4,7 @@ import CalendarTodayIcon from "@material-ui/icons/CalendarToday";
 
 import Text from "@Style/Text";
 
-const Milestone = ({ title, date, description }) => {
+const Milestone = ({ title, date, description, history }) => {
   return (
     <>
       <Wrapper>
@@ -33,7 +33,7 @@ const Milestone = ({ title, date, description }) => {
             </Text>
           </StatusBar>
           <AdminWrapper>
-            <Text color="blue" fontSize="sm">
+            <Text color="blue" fontSize="sm" onClick={() => history.push(`/CreateMilestonePage/isEdit`)}>
               Edit
             </Text>
             <Text color="blue" fontSize="sm">

--- a/FE/src/views/MilestonePage/MilestoneHeader/MilestoneHeader.jsx
+++ b/FE/src/views/MilestonePage/MilestoneHeader/MilestoneHeader.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import styled from "styled-components";
+import EventNoteIcon from "@material-ui/icons/EventNote";
+import DoneIcon from "@material-ui/icons/Done";
+
+import Text from "@Style/Text";
+
+const MilestoneHeader = ({ openCount, closeCount }) => {
+  return (
+    <>
+      <Wrapper>
+        <HeaderLink fontWeight="bold" as="a">
+          <EventNoteIcon fontSize="small" />
+          {openCount} Open
+        </HeaderLink>
+        <HeaderLink fontWeight="bold" as="a">
+          <DoneIcon fontSize="small" />
+          {closeCount} Close
+        </HeaderLink>
+      </Wrapper>
+    </>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const HeaderLink = styled(Text)`
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+  cursor: pointer;
+  svg {
+    margin-right: 5px;
+  }
+`;
+
+export default MilestoneHeader;

--- a/FE/src/views/MilestonePage/MilestonePage.jsx
+++ b/FE/src/views/MilestonePage/MilestonePage.jsx
@@ -24,7 +24,7 @@ const MilestonePage = (props) => {
       <NavBarWrap>
         <NavBar>
           <NavigationButton history={props.history} isMilestone />
-          <Button onClick={() => setIsOpenNewLabel(!isOpenNewLabel)}>New Label</Button>
+          <Button onClick={() => props.history.push(`/CreateIssuePage/isCreate`)}>New Milestone</Button>
         </NavBar>
       </NavBarWrap>
       <Table tableHeader={<MilestoneHeader openCount={5} closeCount={3} />} tableList={MilestoneList} />

--- a/FE/src/views/MilestonePage/MilestonePage.jsx
+++ b/FE/src/views/MilestonePage/MilestonePage.jsx
@@ -12,9 +12,9 @@ import Table from "@Table/Table";
 const MilestonePage = (props) => {
   const MilestoneList = (
     <>
-      <Milestone title="FE 1주차" date="June 12, 2020"></Milestone>
-      <Milestone title="BE 1주차" date="June 12, 2020" description="설명입니다."></Milestone>
-      <Milestone title="BE 1주차" date="June 12, 2020" description="설명입니다."></Milestone>
+      <Milestone title="FE 1주차" date="June 12, 2020" history={props.history}></Milestone>
+      <Milestone title="BE 1주차" date="June 12, 2020" description="설명입니다." history={props.history}></Milestone>
+      <Milestone title="BE 1주차" date="June 12, 2020" description="설명입니다." history={props.history}></Milestone>
     </>
   );
 

--- a/FE/src/views/MilestonePage/MilestonePage.jsx
+++ b/FE/src/views/MilestonePage/MilestonePage.jsx
@@ -1,7 +1,49 @@
 import React from "react";
+import styled from "styled-components";
 
-const MilestonePage = () => {
-  return <div></div>;
+import Button from "@Style/Button";
+
+import Header from "@Header/Header";
+import NavigationButton from "@NavigationButton/NavigationButton";
+import Milestone from "@MilestonePage/Milestone/Milestone";
+import MilestoneHeader from "@MilestonePage/MilestoneHeader/MilestoneHeader";
+import Table from "@Table/Table";
+
+const MilestonePage = (props) => {
+  const MilestoneList = (
+    <>
+      <Milestone title="FE 1주차" date="June 12, 2020"></Milestone>
+      <Milestone title="BE 1주차" date="June 12, 2020" description="설명입니다."></Milestone>
+      <Milestone title="BE 1주차" date="June 12, 2020" description="설명입니다."></Milestone>
+    </>
+  );
+
+  return (
+    <>
+      <Header history={props.history} />
+      <NavBarWrap>
+        <NavBar>
+          <NavigationButton history={props.history} isMilestone />
+          <Button onClick={() => setIsOpenNewLabel(!isOpenNewLabel)}>New Label</Button>
+        </NavBar>
+      </NavBarWrap>
+      <Table tableHeader={<MilestoneHeader openCount={5} closeCount={3} />} tableList={MilestoneList} />
+    </>
+  );
 };
+
+const NavBarWrap = styled.nav`
+  display: flex;
+  justify-content: center;
+  margin-bottom: 40px;
+`;
+
+const NavBar = styled.nav`
+  width: 65%;
+  height: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 
 export default MilestonePage;

--- a/FE/src/views/MilestonePage/MilestonePage.jsx
+++ b/FE/src/views/MilestonePage/MilestonePage.jsx
@@ -24,7 +24,7 @@ const MilestonePage = (props) => {
       <NavBarWrap>
         <NavBar>
           <NavigationButton history={props.history} isMilestone />
-          <Button onClick={() => props.history.push(`/CreateIssuePage/isCreate`)}>New Milestone</Button>
+          <Button onClick={() => props.history.push(`/CreateMilestonePage/isCreate`)}>New Milestone</Button>
         </NavBar>
       </NavBarWrap>
       <Table tableHeader={<MilestoneHeader openCount={5} closeCount={3} />} tableList={MilestoneList} />


### PR DESCRIPTION
### 구현한 내용

<img width="958" alt="Screen Shot 2020-06-12 at 19 22 06" src="https://user-images.githubusercontent.com/30427711/84492991-02560680-ace2-11ea-9616-3cd438b6900a.png">

- 마일스톤 헤더와 마일스톤 컴포넌트를 생성해 테이블에 넣어 마일스톤 목록 페이지 작성
- Edit 누르면 마일스톤 수정 페이지로 이동
- New Milestone 누르면 마일스톤 생성 페이지로 이동
- 마일스톤 상태바는 임시로 작성하였음 -> 데이터 연결하면서 props 수정 필요

Close #7 
