### PR TITLE
[FE] 라벨 페이지 - GET API 연결 / 상태관리

### DIFF
--- a/FE/src/components/InputBox/PersonalInputBox.jsx
+++ b/FE/src/components/InputBox/PersonalInputBox.jsx
@@ -1,15 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import Text from "@Style/Text";
 
 const PersonalInputBox = ({ title, widthSize, value, backgroundColor, placeholder }) => {
+  const [inputValue, setInputValue] = useState("");
+
+  const onChangeValue = ({ target }) => {
+    setInputValue(target.value);
+  };
+
   return (
     <>
       <Wrap>
         <Text children={title} fontWeight="bold" />
         {value ? (
-          <InputBox type="text" widthSize={widthSize} value={value} backgroundColor={backgroundColor} placeholder={placeholder} readOnly />
+          <InputBox
+            type="text"
+            widthSize={widthSize}
+            defaultValue={value}
+            backgroundColor={backgroundColor}
+            placeholder={placeholder}
+            onChange={onChangeValue}
+          />
         ) : (
           <InputBox type="text" widthSize={widthSize} backgroundColor={backgroundColor} placeholder={placeholder} />
         )}

--- a/FE/src/components/InputBox/PersonalInputBox.jsx
+++ b/FE/src/components/InputBox/PersonalInputBox.jsx
@@ -1,15 +1,9 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
 import Text from "@Style/Text";
 
-const PersonalInputBox = ({ title, widthSize, value, backgroundColor, placeholder }) => {
-  const [inputValue, setInputValue] = useState("");
-
-  const onChangeValue = ({ target }) => {
-    setInputValue(target.value);
-  };
-
+const PersonalInputBox = ({ title, widthSize, value, backgroundColor, placeholder, onChange }) => {
   return (
     <>
       <Wrap>
@@ -21,7 +15,7 @@ const PersonalInputBox = ({ title, widthSize, value, backgroundColor, placeholde
             defaultValue={value}
             backgroundColor={backgroundColor}
             placeholder={placeholder}
-            onChange={onChangeValue}
+            onChange={onChange}
           />
         ) : (
           <InputBox type="text" widthSize={widthSize} backgroundColor={backgroundColor} placeholder={placeholder} />

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -4,3 +4,5 @@ import { API_URL } from "@Constants/url";
 export const getIssue = () => axios.get(`${API_URL.issue}`);
 
 export const getLabel = () => axios.get(`${API_URL.label}`);
+
+export const deleteLabel = (labelName) => axios.delete(`${API_URL.label}${labelName}`);

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -1,8 +1,10 @@
 import axios from "axios";
 import { API_URL } from "@Constants/url";
 
-export const getIssue = () => axios.get(`${API_URL.issue}`);
+export const getIssue = () => axios.get(API_URL.issue);
 
-export const getLabel = () => axios.get(`${API_URL.label}`);
+export const getLabel = () => axios.get(API_URL.label);
+
+export const createLabel = (params) => axios.post(API_URL.label, params);
 
 export const deleteLabel = (labelName) => axios.delete(`${API_URL.label}${labelName}`);

--- a/FE/src/lib/createRequestThunk.js
+++ b/FE/src/lib/createRequestThunk.js
@@ -10,7 +10,7 @@ export default function createRequestThunk(type, request) {
       const response = await request(params);
       dispatch({
         type: SUCCESS,
-        payload: response.data.issues,
+        payload: response.data,
       });
       dispatch(finishLoading(type));
     } catch (e) {

--- a/FE/src/modules/index.js
+++ b/FE/src/modules/index.js
@@ -1,8 +1,11 @@
 import { combineReducers } from "redux";
-import issue from "./issue";
-import loading from "./loading";
+
+import loading from "@Modules/loading";
+import issue from "@Modules/issue";
+import label from "@Modules/label";
 
 export default combineReducers({
-  issue,
   loading,
+  issue,
+  label,
 });

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -15,7 +15,7 @@ const issue = handleActions(
   {
     [GET_ISSUE_SUCCESS]: (state, action) => ({
       ...state,
-      issues: action.payload,
+      issues: action.payload.issues,
     }),
   },
   initialState

--- a/FE/src/modules/label.js
+++ b/FE/src/modules/label.js
@@ -3,11 +3,17 @@ import createRequestThunk from "../lib/createRequestThunk";
 import * as api from "@Lib/api";
 
 const GET_LABEL = "label/GET_LABEL";
-const DELETE_LABEL = "label/DELETE_LABEL";
 const GET_LABEL_SUCCESS = "label/GET_LABEL_SUCCESS";
+
+const POST_LABEL = "label/POST_LABEL";
+const POST_LABEL_SUCCESS = "label/POST_LABEL_SUCCESS";
+
+const DELETE_LABEL = "label/DELETE_LABEL";
 const DELETE_LABEL_SUCCESS = "label/DELETE_LABEL_SUCCESS";
+const DELETE_LABEL_FAILURE = "label/DELETE_LABEL_FAILURE";
 
 export const getLabel = createRequestThunk(GET_LABEL, api.getLabel);
+export const createLabel = (params) => createRequestThunk(POST_LABEL, api.createLabel(params));
 export const deleteLabel = (name) => createRequestThunk(DELETE_LABEL, api.deleteLabel(name));
 
 const initialState = {
@@ -20,9 +26,17 @@ const label = handleActions(
       ...state,
       labels: action.payload,
     }),
+    [POST_LABEL_SUCCESS]: (state, action) => ({
+      ...state,
+      labels: action.payload,
+    }),
     [DELETE_LABEL_SUCCESS]: (state, action) => ({
       ...state,
       labels: state.labels.filter((label) => label !== action.payload),
+    }),
+    [DELETE_LABEL_FAILURE]: (state, action) => ({
+      ...state,
+      labels: action.payload,
     }),
   },
   initialState

--- a/FE/src/modules/label.js
+++ b/FE/src/modules/label.js
@@ -1,0 +1,25 @@
+import { handleActions } from "redux-actions";
+import createRequestThunk from "../lib/createRequestThunk";
+import { useMemo } from "react";
+import * as api from "@Lib/api";
+
+const GET_LABEL = "label/GET_LABEL";
+const GET_LABEL_SUCCESS = "label/GET_LABEL_SUCCESS";
+
+export const getLabel = createRequestThunk(GET_LABEL, api.getLabel);
+
+const initialState = {
+  labels: null,
+};
+
+const label = handleActions(
+  {
+    [GET_LABEL_SUCCESS]: (state, action) => ({
+      ...state,
+      labels: action.payload,
+    }),
+  },
+  initialState
+);
+
+export default label;

--- a/FE/src/modules/label.js
+++ b/FE/src/modules/label.js
@@ -1,12 +1,14 @@
 import { handleActions } from "redux-actions";
 import createRequestThunk from "../lib/createRequestThunk";
-import { useMemo } from "react";
 import * as api from "@Lib/api";
 
 const GET_LABEL = "label/GET_LABEL";
+const DELETE_LABEL = "label/DELETE_LABEL";
 const GET_LABEL_SUCCESS = "label/GET_LABEL_SUCCESS";
+const DELETE_LABEL_SUCCESS = "label/DELETE_LABEL_SUCCESS";
 
 export const getLabel = createRequestThunk(GET_LABEL, api.getLabel);
+export const deleteLabel = (name) => createRequestThunk(DELETE_LABEL, api.deleteLabel(name));
 
 const initialState = {
   labels: null,
@@ -17,6 +19,10 @@ const label = handleActions(
     [GET_LABEL_SUCCESS]: (state, action) => ({
       ...state,
       labels: action.payload,
+    }),
+    [DELETE_LABEL_SUCCESS]: (state, action) => ({
+      ...state,
+      labels: state.labels.filter((label) => label !== action.payload),
     }),
   },
   initialState

--- a/FE/src/style/Button.js
+++ b/FE/src/style/Button.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-const Button = styled.button`
+const Button = styled.button.attrs({ type: "button" })`
   background-color: ${({ theme, backgroundColor }) => theme.colors[backgroundColor] || theme.colors.green};
   color: ${({ theme, color }) => theme.colors[color] || theme.colors.white};
   font-size: ${({ theme, fontSize }) => theme.fontSizes[fontSize] || theme.fontSizes.md};

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -48,7 +48,7 @@ const IssueListPage = ({ getIssue, issues, loadingIssue }) => {
           <Button onClick={() => history.push(`/CreateIssuePage`)}>New Issue</Button>
         </NavBar>
       </NavBarWrap>
-      <Table tableHeader={<IssueListHeader />} tableList={<IssueList issues={issues} loadingIssue={loadingIssue} />} />
+      <Table tableHeader={<IssueListHeader />} tableList={<IssueList />} />
     </>
   );
 };

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -9,7 +9,7 @@ import { isDark, randomColor } from "@/lib/getRandomColor";
 
 import PersonalInputBox from "@InputBox/PersonalInputBox";
 
-const CreateLabel = ({ isEdit, defaultColor, isColorDark, name, description }) => {
+const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, description }) => {
   const [backgroundColor, setbackgroundColor] = useState(defaultColor ? defaultColor : randomColor);
   const [isBackDark, setBDark] = useState(isColorDark ? isColorDark : isDark);
   const [inputName, setInputName] = useState(name ? name : "");
@@ -21,6 +21,8 @@ const CreateLabel = ({ isEdit, defaultColor, isColorDark, name, description }) =
 
   const onChangeName = ({ target }) => {
     setInputName(target.value);
+  const createHandler = () => {
+    close();
   };
 
   return (
@@ -45,7 +47,7 @@ const CreateLabel = ({ isEdit, defaultColor, isColorDark, name, description }) =
               </ColorInputBoxWrapper>
             </ColorBoxWrapper>
             <BurrontWrapper>
-              <Button color="black" backgroundColor="white">
+              <Button color="black" backgroundColor="white" onClick={close}>
                 Cancel
               </Button>
               <Button disabled>{isEdit ? "Save Changes" : "Create Label"}</Button>

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -9,41 +9,41 @@ import { isDark, randomColor } from "@/lib/getRandomColor";
 
 import PersonalInputBox from "@InputBox/PersonalInputBox";
 
-const CreateLabel = () => {
-  const [color, setColor] = useState(randomColor);
-  const [bDark, setBDark] = useState(isDark);
+const CreateLabel = ({ isEdit, defaultColor, isColorDark, name, description }) => {
+  const [backgroundColor, setbackgroundColor] = useState(defaultColor ? defaultColor : randomColor);
+  const [isBackDark, setBDark] = useState(isColorDark ? isColorDark : isDark);
 
   const colorReset = () => {
-    setColor(randomColor);
+    setbackgroundColor(randomColor);
     setBDark(isDark);
   };
 
   return (
     <>
       <Wrapper>
-        <Contents>
+        <Contents isEdit={isEdit}>
           <BadgeWrapper>
-            <Badge big backgroundColor={color} color={bDark ? "white" : "black"} style={{ display: "inline-block" }}>
-              Label preview
+            <Badge big backgroundColor={backgroundColor} color={isBackDark ? "white" : "black"} style={{ display: "inline-block" }}>
+              {name ? name : "Label preview"}
             </Badge>
           </BadgeWrapper>
           <LabelInputWrapper>
-            <PersonalInputBox title="Label name" />
-            <PersonalInputBox title="Description" widthSize="320px" />
+            <PersonalInputBox title="Label name" placeholder="Label name" value={name ? name : ""} />
+            <PersonalInputBox title="Description" placeholder="Description (optional)" value={description ? description : ""} widthSize="320px" />
             <ColorBoxWrapper>
               <Text children="Color" fontWeight="bold" />
               <ColorInputBoxWrapper>
-                <ColorResetButton onClick={colorReset} backgroundColor={color}>
-                  <CachedRoundedIcon fontSize="small" style={{ color: bDark ? "white" : "black" }} />
+                <ColorResetButton onClick={colorReset} backgroundColor={backgroundColor}>
+                  <CachedRoundedIcon fontSize="small" style={{ color: isBackDark ? "white" : "black" }} />
                 </ColorResetButton>
-                <PersonalInputBox widthSize="80px" value={color} />
+                <PersonalInputBox widthSize="80px" value={backgroundColor} />
               </ColorInputBoxWrapper>
             </ColorBoxWrapper>
             <BurrontWrapper>
               <Button color="black" backgroundColor="white">
                 Cancel
               </Button>
-              <Button disabled>Create Label</Button>
+              <Button disabled>{isEdit ? "Save Changes" : "Create Label"}</Button>
             </BurrontWrapper>
           </LabelInputWrapper>
         </Contents>
@@ -59,12 +59,12 @@ const Wrapper = styled.div`
 `;
 
 const Contents = styled.form`
-  width: 65%;
+  width: ${({ isEdit }) => (isEdit ? "100%" : "65%")};
   max-width: 1000px;
   height: 150px;
   padding: 16px;
   border-radius: 3px;
-  background-color: ${({ theme }) => theme.colors.gray1};
+  background-color: ${({ theme, isEdit }) => (isEdit ? theme.colors.white : theme.colors.gray1)};
   border: 1px solid ${({ theme }) => theme.colors.gray2};
 `;
 

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -10,9 +10,11 @@ import { isDark, randomColor } from "@/lib/getRandomColor";
 import PersonalInputBox from "@InputBox/PersonalInputBox";
 
 const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, description }) => {
+  const initLabelName = name ? name : "";
+
   const [backgroundColor, setbackgroundColor] = useState(defaultColor ? defaultColor : randomColor);
   const [isBackDark, setBDark] = useState(isColorDark ? isColorDark : isDark);
-  const [inputName, setInputName] = useState(name ? name : "");
+  const [inputName, setInputName] = useState(initLabelName);
   const [inputDesc, setInputDesc] = useState(description ? description : "");
 
   const colorReset = () => {

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -5,8 +5,8 @@ import CachedRoundedIcon from "@material-ui/icons/CachedRounded";
 import Badge from "@Style/Badge";
 import Button from "@Style/Button";
 import Text from "@Style/Text";
-import { isDark, randomColor } from "@/lib/getRandomColor";
 
+import { isDark, randomColor } from "@/lib/getRandomColor";
 import PersonalInputBox from "@InputBox/PersonalInputBox";
 
 const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, description }) => {

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -13,6 +13,7 @@ const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, descripti
   const [backgroundColor, setbackgroundColor] = useState(defaultColor ? defaultColor : randomColor);
   const [isBackDark, setBDark] = useState(isColorDark ? isColorDark : isDark);
   const [inputName, setInputName] = useState(name ? name : "");
+  const [inputDesc, setInputDesc] = useState(description ? description : "");
 
   const colorReset = () => {
     setbackgroundColor(randomColor);
@@ -21,6 +22,9 @@ const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, descripti
 
   const onChangeName = ({ target }) => {
     setInputName(target.value);
+
+  const onChangeDesc = ({ target }) => setInputDesc(target.value);
+
   const createHandler = () => {
     close();
   };
@@ -36,7 +40,13 @@ const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, descripti
           </BadgeWrapper>
           <LabelInputWrapper>
             <PersonalInputBox title="Label name" placeholder="Label name" value={name ? name : ""} onChange={onChangeName} />
-            <PersonalInputBox title="Description" placeholder="Description (optional)" value={description ? description : ""} widthSize="320px" />
+            <PersonalInputBox
+              title="Description"
+              placeholder="Description (optional)"
+              value={description ? description : ""}
+              onChange={onChangeDesc}
+              widthSize="320px"
+            />
             <ColorBoxWrapper>
               <Text children="Color" fontWeight="bold" />
               <ColorInputBoxWrapper>

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -77,7 +77,9 @@ const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, descripti
               <Button color="black" backgroundColor="white" onClick={close}>
                 Cancel
               </Button>
-              <Button disabled>{isEdit ? "Save Changes" : "Create Label"}</Button>
+              <Button disabled={initLabelName === inputName} onClick={createHandler}>
+                {isEdit ? "Save Changes" : "Create Label"}
+              </Button>
             </BurrontWrapper>
           </LabelInputWrapper>
         </Contents>

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -7,6 +7,7 @@ import Button from "@Style/Button";
 import Text from "@Style/Text";
 
 import { isDark, randomColor } from "@/lib/getRandomColor";
+import { createLabel } from "@Modules/label";
 import PersonalInputBox from "@InputBox/PersonalInputBox";
 
 const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, description }) => {
@@ -17,17 +18,31 @@ const CreateLabel = ({ isEdit, close, defaultColor, isColorDark, name, descripti
   const [inputName, setInputName] = useState(initLabelName);
   const [inputDesc, setInputDesc] = useState(description ? description : "");
 
+  const params = {
+    name: inputName,
+    description: inputDesc,
+    color: backgroundColor,
+  };
+
   const colorReset = () => {
     setbackgroundColor(randomColor);
     setBDark(isDark);
   };
 
-  const onChangeName = ({ target }) => {
-    setInputName(target.value);
+  const onChangeName = ({ target }) => setInputName(target.value);
 
   const onChangeDesc = ({ target }) => setInputDesc(target.value);
 
   const createHandler = () => {
+    const fn = async () => {
+      try {
+        await createLabel(params);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fn();
+
     close();
   };
 

--- a/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
+++ b/FE/src/views/LabelListPage/CreateLabel/CreateLabel.jsx
@@ -12,10 +12,15 @@ import PersonalInputBox from "@InputBox/PersonalInputBox";
 const CreateLabel = ({ isEdit, defaultColor, isColorDark, name, description }) => {
   const [backgroundColor, setbackgroundColor] = useState(defaultColor ? defaultColor : randomColor);
   const [isBackDark, setBDark] = useState(isColorDark ? isColorDark : isDark);
+  const [inputName, setInputName] = useState(name ? name : "");
 
   const colorReset = () => {
     setbackgroundColor(randomColor);
     setBDark(isDark);
+  };
+
+  const onChangeName = ({ target }) => {
+    setInputName(target.value);
   };
 
   return (
@@ -24,11 +29,11 @@ const CreateLabel = ({ isEdit, defaultColor, isColorDark, name, description }) =
         <Contents isEdit={isEdit}>
           <BadgeWrapper>
             <Badge big backgroundColor={backgroundColor} color={isBackDark ? "white" : "black"} style={{ display: "inline-block" }}>
-              {name ? name : "Label preview"}
+              {inputName ? inputName : "Label preview"}
             </Badge>
           </BadgeWrapper>
           <LabelInputWrapper>
-            <PersonalInputBox title="Label name" placeholder="Label name" value={name ? name : ""} />
+            <PersonalInputBox title="Label name" placeholder="Label name" value={name ? name : ""} onChange={onChangeName} />
             <PersonalInputBox title="Description" placeholder="Description (optional)" value={description ? description : ""} widthSize="320px" />
             <ColorBoxWrapper>
               <Text children="Color" fontWeight="bold" />

--- a/FE/src/views/LabelListPage/Label/Label.jsx
+++ b/FE/src/views/LabelListPage/Label/Label.jsx
@@ -50,7 +50,6 @@ const Label = ({ label: { name, description, color, isFontColorBlack } }) => {
           </ButtonWrapper>
         </Wrapper>
       )}
-      {/* {isOpenEditLabel && <CreateLabel />} */}
     </>
   );
 };

--- a/FE/src/views/LabelListPage/Label/Label.jsx
+++ b/FE/src/views/LabelListPage/Label/Label.jsx
@@ -1,33 +1,56 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import Text from "@Style/Text";
 import Badge from "@Style/Badge";
 import Button from "@Style/Button";
 
+import { deleteLabel } from "@Modules/label";
+import CreateLabel from "@LabelListPage/CreateLabel/CreateLabel";
+
 const Label = ({ label: { name, description, color, isFontColorBlack } }) => {
+  const [isOpenEditLabel, setIsOpenEditLabel] = useState(false);
+
+  const editLabelOpenHandler = () => setIsOpenEditLabel(!isOpenEditLabel);
+
+  const deleteHandler = () => {
+    const fn = async () => {
+      try {
+        await deleteLabel(name);
+      } catch (e) {
+        console.log(e);
+      }
+    };
+    fn();
+  };
+
   return (
     <>
-      <Wrapper>
-        <BadgeWrapper>
-          <Badge big color={isFontColorBlack ? "black" : "white"} backgroundColor={color} style={{ display: "inline-block" }}>
-            {name}
-          </Badge>
-        </BadgeWrapper>
-        <TextWrapper>
-          <Text color="gray4" lineHeight="30px">
-            {description}
-          </Text>
-        </TextWrapper>
-        <ButtonWrapper>
-          <Button color="gray4" backgroundColor="white" fontSize="sm" borderColor="white">
-            Edit
-          </Button>
-          <Button color="gray4" backgroundColor="white" fontSize="sm" borderColor="white">
-            Delete
-          </Button>
-        </ButtonWrapper>
-      </Wrapper>
+      {isOpenEditLabel ? (
+        <CreateLabel isEdit defaultColor={color} isColorDark={isFontColorBlack} name={name} description={description} />
+      ) : (
+        <Wrapper>
+          <BadgeWrapper>
+            <Badge big color={isFontColorBlack ? "white" : "black"} backgroundColor={color} style={{ display: "inline-block" }}>
+              {name}
+            </Badge>
+          </BadgeWrapper>
+          <TextWrapper>
+            <Text color="gray4" lineHeight="30px">
+              {description}
+            </Text>
+          </TextWrapper>
+          <ButtonWrapper>
+            <Button color="gray4" backgroundColor="white" fontSize="sm" borderColor="white" onClick={editLabelOpenHandler}>
+              Edit
+            </Button>
+            <Button color="gray4" backgroundColor="white" fontSize="sm" borderColor="white" onClick={deleteHandler}>
+              Delete
+            </Button>
+          </ButtonWrapper>
+        </Wrapper>
+      )}
+      {/* {isOpenEditLabel && <CreateLabel />} */}
     </>
   );
 };

--- a/FE/src/views/LabelListPage/Label/Label.jsx
+++ b/FE/src/views/LabelListPage/Label/Label.jsx
@@ -5,18 +5,18 @@ import Text from "@Style/Text";
 import Badge from "@Style/Badge";
 import Button from "@Style/Button";
 
-const Label = () => {
+const Label = ({ label: { name, description, color, isFontColorBlack } }) => {
   return (
     <>
       <Wrapper>
         <BadgeWrapper>
-          <Badge big color="white" backgroundColor="red" style={{ display: "inline-block" }}>
-            bug
+          <Badge big color={isFontColorBlack ? "black" : "white"} backgroundColor={color} style={{ display: "inline-block" }}>
+            {name}
           </Badge>
         </BadgeWrapper>
         <TextWrapper>
           <Text color="gray4" lineHeight="30px">
-            Something isn't working
+            {description}
           </Text>
         </TextWrapper>
         <ButtonWrapper>
@@ -52,4 +52,4 @@ const ButtonWrapper = styled.div`
   display: flex;
 `;
 
-export default Label;
+export default React.memo(Label);

--- a/FE/src/views/LabelListPage/Label/Label.jsx
+++ b/FE/src/views/LabelListPage/Label/Label.jsx
@@ -27,7 +27,7 @@ const Label = ({ label: { name, description, color, isFontColorBlack } }) => {
   return (
     <>
       {isOpenEditLabel ? (
-        <CreateLabel isEdit defaultColor={color} isColorDark={isFontColorBlack} name={name} description={description} />
+        <CreateLabel isEdit close={editLabelOpenHandler} defaultColor={color} isColorDark={isFontColorBlack} name={name} description={description} />
       ) : (
         <Wrapper>
           <BadgeWrapper>

--- a/FE/src/views/LabelListPage/LabelListPage.jsx
+++ b/FE/src/views/LabelListPage/LabelListPage.jsx
@@ -40,7 +40,7 @@ const LabelListPage = ({ getLabel, labels, loadingLabel }) => {
         </NavBar>
       </NavBarWrap>
       {isOpenNewLabel && <CreateLabel />}
-      <Table tableHeader={<LabelListHeader count={2} />} tableList={<LabelList />} />
+      <Table tableHeader={<LabelListHeader count={!loadingLabel && labels && labels.length} />} tableList={<LabelList />} />
     </>
   );
 };

--- a/FE/src/views/LabelListPage/LabelListPage.jsx
+++ b/FE/src/views/LabelListPage/LabelListPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { connect } from "react-redux";
 
@@ -12,15 +12,21 @@ import Header from "@Header/Header";
 import Table from "@Table/Table";
 import { getLabel } from "@Modules/label";
 
-const LabelListPage = () => {
+const LabelListPage = ({ getLabel, labels, loadingLabel }) => {
   const [isOpenNewLabel, setIsOpenNewLabel] = useState(false);
 
-  const labelList = (
-    <>
-      <Label></Label>
-      <Label></Label>
-    </>
-  );
+  const LabelList = () => <>{!loadingLabel && labels && labels.map((label) => <Label key={label.name} label={label} />)}</>;
+
+  useEffect(() => {
+    const fn = async () => {
+      try {
+        await getLabel();
+      } catch (e) {
+        console.log(e);
+      }
+    };
+    fn();
+  }, [getLabel]);
 
   return (
     <>
@@ -32,7 +38,7 @@ const LabelListPage = () => {
         </NavBar>
       </NavBarWrap>
       {isOpenNewLabel && <CreateLabel />}
-      <Table tableHeader={<LabelListHeader count={2} />} tableList={labelList} />
+      <Table tableHeader={<LabelListHeader count={2} />} tableList={<LabelList />} />
     </>
   );
 };

--- a/FE/src/views/LabelListPage/LabelListPage.jsx
+++ b/FE/src/views/LabelListPage/LabelListPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { connect } from "react-redux";
 
 import Button from "@Style/Button";
 
@@ -9,6 +10,7 @@ import NavigationButton from "@NavigationButton/NavigationButton";
 import CreateLabel from "@LabelListPage/CreateLabel/CreateLabel";
 import Header from "@Header/Header";
 import Table from "@Table/Table";
+import { getLabel } from "@Modules/label";
 
 const LabelListPage = () => {
   const [isOpenNewLabel, setIsOpenNewLabel] = useState(false);
@@ -50,4 +52,12 @@ const NavBar = styled.nav`
   align-items: center;
 `;
 
-export default LabelListPage;
+export default connect(
+  ({ label, loading }) => ({
+    labels: label.labels,
+    loadingLabel: loading["label/GET_LABEL"],
+  }),
+  {
+    getLabel,
+  }
+)(React.memo(LabelListPage));

--- a/FE/src/views/LabelListPage/LabelListPage.jsx
+++ b/FE/src/views/LabelListPage/LabelListPage.jsx
@@ -39,7 +39,7 @@ const LabelListPage = ({ getLabel, labels, loadingLabel }) => {
           <Button onClick={newLabelOpenHandler}>New Label</Button>
         </NavBar>
       </NavBarWrap>
-      {isOpenNewLabel && <CreateLabel />}
+      {isOpenNewLabel && <CreateLabel close={newLabelOpenHandler} />}
       <Table tableHeader={<LabelListHeader count={!loadingLabel && labels && labels.length} />} tableList={<LabelList />} />
     </>
   );

--- a/FE/src/views/LabelListPage/LabelListPage.jsx
+++ b/FE/src/views/LabelListPage/LabelListPage.jsx
@@ -15,6 +15,8 @@ import { getLabel } from "@Modules/label";
 const LabelListPage = ({ getLabel, labels, loadingLabel }) => {
   const [isOpenNewLabel, setIsOpenNewLabel] = useState(false);
 
+  const newLabelOpenHandler = () => setIsOpenNewLabel(!isOpenNewLabel);
+
   const LabelList = () => <>{!loadingLabel && labels && labels.map((label) => <Label key={label.name} label={label} />)}</>;
 
   useEffect(() => {
@@ -34,7 +36,7 @@ const LabelListPage = ({ getLabel, labels, loadingLabel }) => {
       <NavBarWrap>
         <NavBar>
           <NavigationButton isLabel />
-          <Button onClick={() => setIsOpenNewLabel(!isOpenNewLabel)}>New Label</Button>
+          <Button onClick={newLabelOpenHandler}>New Label</Button>
         </NavBar>
       </NavBarWrap>
       {isOpenNewLabel && <CreateLabel />}


### PR DESCRIPTION
### 구현한 내용

- 라벨 페이지 목록 데이터 API 연결
- edit 버튼 클릭 시 edit으로 뜨고 값 변경되도록 수정 (api 연결은 추후 예정)
-  이슈 변경 로컬에서 입력값 상태관리하도록 추가
- DELETE, POST 메소드는 요청은 가지만 랜더 처리는 되어 있지 않음

Close #63 