### PR TITLE
[BE] 마일스톤 관련 API 구현 중

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/common/exception/ErrorMessage.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/common/exception/ErrorMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ErrorMessage {
   
     LABEL_NAME_DUPLICATED("Name has already been taken"),
-    MILESTONE_TITLE_DUPLICATED("Title has already been taken");
+    MILESTONE_TITLE_DUPLICATED("Title has already been taken"),
+    ENTITY_UPDATE_FAILED("Failed to update");
 
     private String message;
     

--- a/BE/src/main/java/com/codesquad/issuetracker/common/exception/ErrorMessage.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/common/exception/ErrorMessage.java
@@ -9,7 +9,8 @@ public enum ErrorMessage {
   
     LABEL_NAME_DUPLICATED("Name has already been taken"),
     MILESTONE_TITLE_DUPLICATED("Title has already been taken"),
-    ENTITY_UPDATE_FAILED("Failed to update");
+    ENTITY_UPDATE_FAILED("Failed to update"),
+    ENTITY_DELETE_FAILED("Failed to delete");
 
     private String message;
     

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
@@ -92,4 +92,8 @@ public class MilestoneService {
     public boolean changeStatus(MilestoneId milestoneId) {
         return mileStoneRepository.changeStatus(milestoneId) > 0;
     }
+
+    public void deleteMilestone(MilestoneId milestoneId) {
+        mileStoneRepository.deleteById(milestoneId);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
@@ -88,4 +88,8 @@ public class MilestoneService {
         // save는 Milestone의 모든 정보를 변경하므로 update 쿼리를 직접 작성한다.
         mileStoneRepository.updateMilestone(milestone);
     }
+
+    public boolean changeStatus(MilestoneId milestoneId) {
+        return mileStoneRepository.changeStatus(milestoneId) > 0;
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
@@ -83,4 +83,9 @@ public class MilestoneService {
             put("achievementRate", (long)(get("numberOfOpenIssue") * 1.f / issues.size() * 100));
         }};
     }
+
+    public void modifyMilestone(Milestone milestone) {
+        // save는 Milestone의 모든 정보를 변경하므로 update 쿼리를 직접 작성한다.
+        mileStoneRepository.updateMilestone(milestone);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/MileStoneRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/MileStoneRepository.java
@@ -1,8 +1,22 @@
 package com.codesquad.issuetracker.milestone.domain;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
-public interface MileStoneRepository extends CrudRepository<Milestone, Long> {
+import javax.transaction.Transactional;
+
+public interface MileStoneRepository extends CrudRepository<Milestone, MilestoneId> {
 
     public Milestone findFirstByOrderByIdDesc();
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Milestone " +
+            "SET  title = :#{#milestone.title}," +
+            "      description = :#{#milestone.description}," +
+            "      due_date = :#{#milestone.dueDate} " +
+            "WHERE milestone_id = :#{#milestone.id.milestoneId}")
+    public void updateMilestone(@Param("milestone") Milestone milestone);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/MileStoneRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/MileStoneRepository.java
@@ -19,4 +19,14 @@ public interface MileStoneRepository extends CrudRepository<Milestone, Milestone
             "      due_date = :#{#milestone.dueDate} " +
             "WHERE milestone_id = :#{#milestone.id.milestoneId}")
     public void updateMilestone(@Param("milestone") Milestone milestone);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Milestone " +
+            "SET   is_open = " +
+            "      CASE is_open " +
+            "      WHEN TRUE THEN FALSE" +
+            "      ELSE TRUE END " +
+            "WHERE milestone_id = :#{#milestoneId.milestoneId}")
+    public int changeStatus(@Param("milestoneId") MilestoneId milestoneId);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/Milestone.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/Milestone.java
@@ -2,6 +2,7 @@ package com.codesquad.issuetracker.milestone.domain;
 
 import com.codesquad.issuetracker.common.BaseTimeEntity;
 import com.codesquad.issuetracker.issue.domain.IssueId;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -30,6 +31,7 @@ public class Milestone extends BaseTimeEntity {
     @Column(name = "title", unique = true)
     private String title;
 
+    @JsonProperty(value = "due_date")
     private LocalDate dueDate;
 
     private String description;

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/Milestone.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/Milestone.java
@@ -1,6 +1,7 @@
 package com.codesquad.issuetracker.milestone.domain;
 
 import com.codesquad.issuetracker.common.BaseTimeEntity;
+import com.codesquad.issuetracker.issue.domain.Issue;
 import com.codesquad.issuetracker.issue.domain.IssueId;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import lombok.Setter;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -37,4 +39,31 @@ public class Milestone extends BaseTimeEntity {
     private String description;
 
     private boolean isOpen = true;
+
+    @Transient
+    public long numberOfOpenIssue;
+
+    @Transient
+    public long numberOfClosedIssue;
+
+    @Transient
+    public int achievementRate;
+
+    public void setMetaData(List<Issue> issues) {
+        this.numberOfOpenIssue = countNumberOfOpenIssue(issues);
+        this.numberOfClosedIssue = countNumberOfClosedIssue(issues);
+        this.achievementRate = calculateAchievementRate(issues.size());
+    }
+
+    private long countNumberOfOpenIssue(List<Issue> issue) {
+        return issue.stream().filter(Issue::getIsOpen).count();
+    }
+
+    private long countNumberOfClosedIssue(List<Issue> issue) {
+        return issue.stream().filter(i -> !i.getIsOpen()).count();
+    }
+
+    private int calculateAchievementRate(int numberOfIssue) {
+        return (int)(numberOfClosedIssue * 1.f / numberOfIssue * 100);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/ui/MilestoneController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/ui/MilestoneController.java
@@ -8,6 +8,7 @@ import com.codesquad.issuetracker.milestone.domain.MilestoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -37,7 +38,7 @@ public class MilestoneController {
 
     @PutMapping("/{milestone_id}")
     public ResponseEntity<?> modifyMilestone(@PathVariable(name = "milestone_id") Long milestoneId,
-                                                @RequestBody Milestone milestone) {
+                                             @RequestBody Milestone milestone) {
         milestone.setId(new MilestoneId(milestoneId));
         try {
             milestoneService.modifyMilestone(milestone);
@@ -52,6 +53,16 @@ public class MilestoneController {
         if (milestoneService.changeStatus(new MilestoneId(milestoneId))) {
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         }
-        return new ResponseEntity<>(ErrorMessage.ENTITY_UPDATE_FAILED.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ResponseEntity<>(ErrorMessage.ENTITY_UPDATE_FAILED.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @DeleteMapping("/{milestone_id}")
+    public ResponseEntity<?> deleteMilestone(@PathVariable(name = "milestone_id") Long milestoneId) {
+        try {
+            milestoneService.deleteMilestone(new MilestoneId(milestoneId));
+        } catch (EmptyResultDataAccessException e) {
+            return new ResponseEntity<>(ErrorMessage.ENTITY_DELETE_FAILED.getMessage(), HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/ui/MilestoneController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/ui/MilestoneController.java
@@ -46,4 +46,12 @@ public class MilestoneController {
         }
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
+
+    @PatchMapping("/{milestone_id}")
+    public ResponseEntity<?> changeStatus(@PathVariable(name = "milestone_id") Long milestoneId) {
+        if (milestoneService.changeStatus(new MilestoneId(milestoneId))) {
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        }
+        return new ResponseEntity<>(ErrorMessage.ENTITY_UPDATE_FAILED.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/ui/MilestoneController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/ui/MilestoneController.java
@@ -4,6 +4,7 @@ import com.codesquad.issuetracker.common.exception.ErrorMessage;
 import com.codesquad.issuetracker.milestone.application.MilestoneService;
 import com.codesquad.issuetracker.milestone.domain.Milestone;
 import com.codesquad.issuetracker.milestone.domain.MilestoneBoard;
+import com.codesquad.issuetracker.milestone.domain.MilestoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -32,5 +33,17 @@ public class MilestoneController {
             return new ResponseEntity<>(ErrorMessage.MILESTONE_TITLE_DUPLICATED.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
         }
         return new ResponseEntity<>("마일스톤 생성 성공", HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{milestone_id}")
+    public ResponseEntity<?> modifyMilestone(@PathVariable(name = "milestone_id") Long milestoneId,
+                                                @RequestBody Milestone milestone) {
+        milestone.setId(new MilestoneId(milestoneId));
+        try {
+            milestoneService.modifyMilestone(milestone);
+        } catch (DataIntegrityViolationException e) {
+            return new ResponseEntity<>(ErrorMessage.MILESTONE_TITLE_DUPLICATED.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }


### PR DESCRIPTION
#58 

### 구현한 기능

- 마일스톤 생성 API
- 마일스톤 목록 API
- 마일스톤 개폐 변경 API
- 마일스톤 데이터 변경 API
- 마일스톤 삭제 API

### 미구현 기능
- 특정 마일스톤 API
  - 이슈 목록 API 구현 후에 진행할 예정 (이슈 목록 가져오는 로직을 재사용할 예정)