### PR TITLE
[BE] DB 시간 데이터 KST로 변경

### DIFF
--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -55,6 +55,6 @@ spring:
   profiles: production
 
   datasource:
-    url: ENC(a2fs4smti6ZnSmajFS6aSs1iAJqBRtYOzX4s76MrfgRZzahIJa/M8W8YuiKIIDgXX41cqBiiVkRCd5S3GttLT2XTyJN61UEXgmwzA436LQy3ifszU+hKcDCJkxJrOeU2DsoNAc2o9Q7KQLjBX3/SAvJRQp+p+su1HSQSP+ebwbTyfv0R90WHrx/IhK88QC5hIS7VDmWusa4qZOR0R1s1BA==)
+    url: ENC(e3w9hMoYfqs+5rqvRbCMhKK9PMEO7x9tfpsdBorh+oLcpQ5K/HezMg1FzdP+OvfVixOkIbCK49jjxGVAdugm73JH6RpOeGlNjqE9vx4hcw1SHqKAhOX6Lf7QT3wsuZhYt6EWaI2BWShafJS1rAf/qXYaMZuwad7Az2Yh3WKQapTfIVIs3RWJId6CqYLujzJZ)
     username: ENC(dWFI/DAXSod1mpm9fOEXhd70DB1D8lOmuYHCA/z7y0CfA5k699XdBzzNQLw5ewHN)
     password: ENC(kBF9VO2QdavUtJyL2oUkx/vjv+AyevUXEQZ5ZCpvDVk5fU7IpGtg5e/R4kh69YeA)


### PR DESCRIPTION
### 변경한 내용

- 리눅스 시간대를 KST로 변경했음에도 불구하고 UTC로 저장되는 현상. datasource url에 serverTimeZone 옵션을 제거하여 다시 encrypt

