### PR TITLE
[BE] 마일스톤 양방향 참조 제거

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/issue/domain/IssueRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/domain/IssueRepository.java
@@ -1,7 +1,18 @@
 package com.codesquad.issuetracker.issue.domain;
 
+import com.codesquad.issuetracker.milestone.domain.MilestoneId;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface IssueRepository extends CrudRepository<Issue, IssueId> {
+
     Issue findFirstByOrderByIdDesc();
+
+    @Query("SELECT i " +
+            "FROM  Issue AS i " +
+            "WHERE milestone_id = :#{#milestoneId.milestoneId}")
+    List<Issue> findByMilestoneId(@Param(value = "milestoneId") MilestoneId milestoneId);
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/application/MilestoneService.java
@@ -49,9 +49,7 @@ public class MilestoneService {
     private List<MilestoneDTO> parseMilestonesToDTO(List<Milestone> milestones) {
         return milestones.stream().map(m -> {
 
-            List<Issue> issues = StreamSupport.stream(issueRepository.findAllById(m.getIssues()).spliterator(), false)
-                    .collect(Collectors.toList());
-
+            List<Issue> issues = issueRepository.findByMilestoneId(m.getId());
             m.setMetaData(issues);
 
             // 현재는 List<IssueDTO>를 세팅하지 않지만 /milestones/{id}/issues에서 필요할 듯

--- a/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/Milestone.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/milestone/domain/Milestone.java
@@ -2,16 +2,16 @@ package com.codesquad.issuetracker.milestone.domain;
 
 import com.codesquad.issuetracker.common.BaseTimeEntity;
 import com.codesquad.issuetracker.issue.domain.Issue;
-import com.codesquad.issuetracker.issue.domain.IssueId;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Transient;
 import javax.validation.constraints.Size;
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -23,13 +23,6 @@ public class Milestone extends BaseTimeEntity {
 
     @EmbeddedId
     private MilestoneId id;
-
-    @ElementCollection (fetch = FetchType.EAGER)
-    @CollectionTable (
-            name = "issue",
-            joinColumns = @JoinColumn(name = "milestone_id")
-    )
-    Set<IssueId> issues = new HashSet<>();
 
     @Size(max = 50)
     @Column(name = "title", unique = true)
@@ -54,7 +47,6 @@ public class Milestone extends BaseTimeEntity {
     public static Milestone of(MilestoneId milestoneId, Milestone milestone) {
         return Milestone.builder()
                 .id(milestoneId)
-                .issues(milestone.issues)
                 .title(milestone.title)
                 .dueDate(milestone.dueDate)
                 .description(milestone.description)


### PR DESCRIPTION
### 변경한 내용

#58 

- `Milestone`에서 `Set<IssueId>` 참조 제거
- `IssueRepository`에 `MilestoneId`로 조회하는 메소드 추가
