### PR TITLE
[BE] 로그인 API 로직 수정

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/config/WebConfig.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/config/WebConfig.java
@@ -10,6 +10,8 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
+
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
@@ -33,8 +35,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(loginInterceptor).addPathPatterns("/**")
-        .excludePathPatterns("users/**");
+        registry.addInterceptor(loginInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(Arrays.asList("/users", "/users/**"));
     }
 
     @Override

--- a/BE/src/main/java/com/codesquad/issuetracker/user/domain/UserRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/user/domain/UserRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface UserRepository extends CrudRepository<User, UserId> {
     User findFirstByOrderByIdDesc();
+
+    User findByNickname(String nickname);
 }


### PR DESCRIPTION
### 변경한 내용

#70

- 로그인 시, id가 아닌 nickname을 기준으로 User 데이터를 조회하도록 수정 (로그인 시에는 id 값을 알지 못하기 때문에)
- 회원가입 시, `loginService.login()`를 호출하여 JWT 토큰과 쿠키를 생성하도록 수정
- Github 로그인 시, `UserId`를 레포지토리에서 구하도록 변경 (만일 Github에서 가져온 id값이 DB에 존재하는 id인 경우를 고려)