### PR TITLE
[BE] 일반 로그인 시도 시, 리다이렉트 하지 않도록 변경

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/issue/ui/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/ui/IssueController.java
@@ -95,9 +95,9 @@ public class IssueController {
 
     @PutMapping("/{issue_id}/milestone")
     public IssueBoard changeMilestone(@PathVariable(name = "issue_id") Long issueId,
-                                      @RequestBody Long milestoneId) {
+                                      @RequestBody Issue issue) {
         IssueId targetIssueId = new IssueId(issueId);
-        MilestoneId targetMilestoneId = new MilestoneId(milestoneId);
+        MilestoneId targetMilestoneId = new MilestoneId(issue.getMilestoneId().getMilestoneId());
         issueService.changeMilestone(targetIssueId, targetMilestoneId);
         return null;
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/user/ui/UserController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/user/ui/UserController.java
@@ -54,14 +54,8 @@ public class UserController {
         loginUser.checkPassword(user);
 
         loginService.login(loginUser, response);
-//        response.sendRedirect("/IssueListPage");
 
-        URI uri = UriComponentsBuilder.fromUriString("http://3.34.110.161/IssueListPage").build().toUri();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(uri);
-
-        return new ResponseEntity<>("로그인 성공", headers, HttpStatus.FOUND);
+        return new ResponseEntity<>("로그인 성공", HttpStatus.NO_CONTENT);
     }
 
     @GetMapping("/oauth/code")


### PR DESCRIPTION
### 변경한 내용

#70 

- Github OAuth 로그인이 아닌 일반 로그인에 성공했을 때, 리다이렉트 하지 않도록 변경
  - 로컬에서 개발하는 경우, CORS 에러 발생하여 FE와 상의 후 위와 같이 처리하기로 함
  - CORS 오류가 나는 이유는 `localhost`에서 로그인을 시도하면 `3.34.110.161/issueListPage`로 리다이렉트되면서 Origin이 변경되기 때문에 그런 듯

#55

- 이슈의 assignee, labels, milestone 변경 시, Request Body를 통일하기 위해 milestone 변경 시에도 커맨드 객체를 Long -> Issue로 받도록 변경
