### PR TITLE
[BE] 이슈 일괄 개폐 변경 수정 사항

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
@@ -65,8 +65,10 @@ public class IssueService {
         return readIssue(newIssue.getId());
     }
 
-    public void changeStatusOfIssues(List<IssueId> issueIds) {
-        issueIds.forEach(this::changeStatus);
+    public void changeStatusOfIssues(List<Number> issueIds, boolean isOpen) {
+        Iterable<Issue> issues = issueRepository.findAllById(issueIds.stream().map(Number::longValue).map(IssueId::new).collect(Collectors.toList()));
+        issues.forEach(i -> i.changeStatus(isOpen));
+        issueRepository.saveAll(issues);
     }
 
     public void changeStatus(IssueId issueId) {

--- a/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
@@ -65,8 +65,8 @@ public class IssueService {
         return readIssue(newIssue.getId());
     }
 
-    public void changeStatusOfIssues(List<Number> issueIds, boolean isOpen) {
-        Iterable<Issue> issues = issueRepository.findAllById(issueIds.stream().map(Number::longValue).map(IssueId::new).collect(Collectors.toList()));
+    public void changeStatusOfIssues(List<IssueId> issueIds, boolean isOpen) {
+        Iterable<Issue> issues = issueRepository.findAllById(issueIds);
         issues.forEach(i -> i.changeStatus(isOpen));
         issueRepository.saveAll(issues);
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/issue/domain/Issue.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/domain/Issue.java
@@ -70,6 +70,10 @@ public class Issue extends BaseTimeEntity {
         this.isOpen = !isOpen;
     }
 
+    public void changeStatus(boolean isOpen) {
+        this.isOpen = isOpen;
+    }
+
     public void editTitle(String title) {
         this.title = title;
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/issue/ui/IssueController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/ui/IssueController.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestController
@@ -41,8 +43,14 @@ public class IssueController {
     }
 
     @PatchMapping("")
-    public ResponseEntity<Void> changeStatusOfIssues(@RequestBody List<IssueId> issueIds) {
-        issueService.changeStatusOfIssues(issueIds);
+    public ResponseEntity<Void> changeStatusOfIssues(@RequestBody Map<String, Object> requestBody) {
+        List<IssueId> issueIds = ((List<Number>) requestBody.get("issues"))
+                .stream()
+                .map(Number::longValue)
+                .map(IssueId::new)
+                .collect(Collectors.toList());
+        boolean isOpen = (boolean) requestBody.get("isOpen");
+        issueService.changeStatusOfIssues(issueIds, isOpen);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 


### PR DESCRIPTION
### 변경한 내용

#55 

- 이슈 일괄 개폐 변경은 Open, Closed가 혼재된 경우에도 사용할 수 있으므로, Request Body에 `isOpen` 프로퍼티를 추가해서 보내는 것으로 변경함
