### PR TITLE
[FE] 이슈 상세 페이지 GET 연결

### DIFF
--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -106,6 +106,7 @@ const CommentContent = styled.div`
   height: 200px;
   padding: 15px;
   overflow: visible;
+  word-break: break-all;
 `;
 
 const CommentText = styled.div`

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -9,17 +9,17 @@ import Badge from "@Style/Badge";
 
 const formatter = buildFormatter(engStrings);
 
-const CommentViewBox = ({ owner }) => {
+const CommentViewBox = ({ owner, createdAt, content, author }) => {
   return (
     <>
       <Wrapper>
-        <Avatar src="https://avatars1.githubusercontent.com/u/30427711?s=88&u=0f6f414055ea0bec267856e35e8902b9f728fe1a&v=4"></Avatar>
+        <Avatar src={owner ? author.avatarUrl : author.avatar_url}></Avatar>
         <CommentGroup>
           <CommentHeader owner={owner ? true : false}>
             <CommentText>
-              <Text fontWeight="extraBold">choisohyun</Text>
+              <Text fontWeight="extraBold">{author.nickname}</Text>
               <Text color="gray4">
-                commented <TimeAgo date="May 25, 2020" formatter={formatter} />
+                commented <TimeAgo date={createdAt} formatter={formatter} />
               </Text>
             </CommentText>
             <CommentAction>
@@ -32,7 +32,7 @@ const CommentViewBox = ({ owner }) => {
               <Text color="gray4">Delete</Text>
             </CommentAction>
           </CommentHeader>
-          <CommentContent></CommentContent>
+          <CommentContent>{content}</CommentContent>
         </CommentGroup>
       </Wrapper>
     </>

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -103,7 +103,6 @@ const CommentHeader = styled.div`
 
 const CommentContent = styled.div`
   width: 100%;
-  height: 200px;
   padding: 15px;
   overflow: visible;
   word-break: break-all;

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import { API_URL } from "@Constants/url";
 
 export const getIssue = () => axios.get(API_URL.issue);
+export const getDetailIssue = (issueId) => axios.get(`${API_URL.issue}${issueId}`);
 
 export const getMilestone = () => axios.get(API_URL.milestone);
 export const getMilestoneDetail = (milestoneId) => axios.get(`${API_URL.milestone}${milestoneId}`);

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -5,10 +5,15 @@ import * as api from "@Lib/api";
 const GET_ISSUE = "issue/GET_ISSUE";
 const GET_ISSUE_SUCCESS = "issue/GET_ISSUE_SUCCESS";
 
+const GET_DETAIL_ISSUE = "issue/GET_DETAIL_ISSUE";
+const GET_DETAIL_ISSUE_SUCCESS = "issue/GET_DETAIL_ISSUE_SUCCESS";
+
 export const getIssue = createRequestThunk(GET_ISSUE, api.getIssue);
+export const getDetailIssue = createRequestThunk(GET_DETAIL_ISSUE, api.getDetailIssue);
 
 const initialState = {
   issues: null,
+  detailIssue: null,
 };
 
 const issue = handleActions(
@@ -16,6 +21,10 @@ const issue = handleActions(
     [GET_ISSUE_SUCCESS]: (state, action) => ({
       ...state,
       issues: action.payload.data.issues,
+    }),
+    [GET_DETAIL_ISSUE_SUCCESS]: (state, action) => ({
+      ...state,
+      detailIssue: action.payload.data,
     }),
   },
   initialState

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -12,6 +12,25 @@ import { getDetailIssue } from "@Modules/issue";
 const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue }) => {
   const { issueId } = useParams();
 
+  const CommentList = () => (
+    <>
+      {!loadingDetailIssue &&
+        detailIssue &&
+        detailIssue.comments.map((comment) => {
+          const {
+            comment: {
+              id: { commentId },
+              createdAt,
+              content,
+            },
+            user,
+          } = comment;
+
+          return <CommentViewBox key={commentId} createdAt={createdAt} content={content} author={user} />;
+        })}
+    </>
+  );
+
   useEffect(() => {
     const fn = async () => {
       try {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -1,14 +1,28 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
+import { connect } from "react-redux";
 
 import FilterVerticalList from "@FilterButton/FilterVerticalList";
 import CommentInputBox from "@InputBox/CommentInputBox/CommentInputBox";
 import Header from "@Header/Header";
 import CommentViewBox from "@CommentViewBox/CommentViewBox";
+import { getDetailIssue } from "@Modules/issue";
 
-const IssueDetailPage = () => {
+const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue }) => {
   const { issueId } = useParams();
+
+  useEffect(() => {
+    const fn = async () => {
+      try {
+        await getDetailIssue(issueId);
+      } catch (e) {
+        console.log(e);
+      }
+    };
+    fn();
+  }, []);
+
   return (
     <>
       <Header />
@@ -48,4 +62,12 @@ const CommentViewBoxWrapper = styled.div`
   width: 75%;
 `;
 
-export default IssueDetailPage;
+export default connect(
+  ({ issue, loading }) => ({
+    detailIssue: issue.detailIssue,
+    loadingDetailIssue: loading["issue/GET_DETAIL_ISSUE"],
+  }),
+  {
+    getDetailIssue,
+  }
+)(IssueDetailPage);

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -48,9 +48,10 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue }) =>
       <ContentWrapper>
         <Content>
           <CommentViewBoxWrapper>
-            <CommentViewBox owner />
-            <CommentViewBox />
-            <CommentViewBox />
+            {!loadingDetailIssue && detailIssue && (
+              <CommentViewBox owner createdAt={detailIssue.createdAt} content={detailIssue.content} author={detailIssue.author} />
+            )}
+            <CommentList />
             <CommentInputBox />
           </CommentViewBoxWrapper>
           <FilterVerticalList />

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -48,7 +48,7 @@ const Issue = ({ issue }) => {
             <Text fontSize="sm">
               <Milestone>
                 <EventNoteIcon style={{ fontSize: 15 }} />
-                스프린트2
+                {issue.milestone.title}
               </Milestone>
             </Text>
           </Info>


### PR DESCRIPTION
### 구현한 내용

- 하드코딩되어 있던 상세 페이지에 실 데이터를 연결함.

<img width="698" alt="Screen Shot 2020-07-13 at 12 39 42" src="https://user-images.githubusercontent.com/30427711/87268674-f9856a00-c505-11ea-8f0c-3bcfab9180f2.png">

Close #125 