### PR TITLE
[BE] 코멘트 관련 변경 사항

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/comment/application/CommentService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/comment/application/CommentService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.Optional;
 
 @Slf4j
@@ -46,7 +47,7 @@ public class CommentService {
     }
 
     private Comment findCommentById(CommentId commentId) {
-        return commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다!"));
+        return commentRepository.findById(commentId).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 댓글입니다!"));
     }
 
     public long countByIssueId(IssueId issueId) {

--- a/BE/src/main/java/com/codesquad/issuetracker/comment/ui/CommentController.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/comment/ui/CommentController.java
@@ -47,7 +47,7 @@ public class CommentController {
     }
 
     @PatchMapping("/{comment_id}")
-    public ResponseEntity<String> changeStatus(@PathVariable("issue_id") Long issueId,
+    public ResponseEntity<Void> changeStatus(@PathVariable("issue_id") Long issueId,
                                                @PathVariable("comment_id") Long commentId,
                                                HttpServletRequest request) {
 
@@ -56,11 +56,11 @@ public class CommentController {
 
         commentService.changeStatus(compositeCommentId);
 
-        return new ResponseEntity<>("댓글 상태 변경 성공", HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping("/{comment_id}")
-    public ResponseEntity<String> delete(@PathVariable("issue_id") Long issueId,
+    public ResponseEntity<Void> delete(@PathVariable("issue_id") Long issueId,
                                          @PathVariable("comment_id") Long commentId,
                                          HttpServletRequest request) {
 
@@ -69,7 +69,7 @@ public class CommentController {
 
         commentService.delete(compositeCommentId);
 
-        return new ResponseEntity<>("댓글 삭제 성공", HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }
 

--- a/BE/src/main/java/com/codesquad/issuetracker/user/domain/User.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/user/domain/User.java
@@ -2,6 +2,7 @@ package com.codesquad.issuetracker.user.domain;
 
 import com.codesquad.issuetracker.common.exception.UnauthorizedException;
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
@@ -30,9 +31,10 @@ public class User {
     @JsonProperty("avatar_url")
     private String avatarUrl = "https://codesquad-project.s3.ap-northeast-2.amazonaws.com/sad.jpg";
 
-    @JsonProperty("email")
+    @JsonIgnore
     private String email;
 
+    @JsonIgnore
     private String password;
 
     public static User of(UserId userId, User user) {

--- a/BE/src/main/java/com/codesquad/issuetracker/user/infrastructure/LoginInterceptor.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/user/infrastructure/LoginInterceptor.java
@@ -37,8 +37,7 @@ public class LoginInterceptor extends HandlerInterceptorAdapter {
         log.debug("Remote Address:{}", request.getRemoteAddr());
         log.debug("Remote User :{}", request.getRemoteUser());
 
-        // By.Jay - 개발용 코드
-        if (!request.getMethod().equals("POST")) {
+        if (!request.getRequestURI().contains("/issues") && !request.getMethod().equals("POST")) {
             return true;
         }
 


### PR DESCRIPTION
### 변경한 내용

#123 

- `User` 가 JSON에 포함되는 경우, `email`과 `password` 제거
- 코멘트가 존재하지 않는 경우 예외 클래스 `IllegalArgumentException` => `EntityNotFoundException`으로 변경
- 코멘트 컨트롤러 메소드 중 응답 코드가 204인 경우 `ResponseEntity<Void>` 로 반환 타입 변경

#121
- 로그인 후, localhost로 이동 시 쿠키가 유지되지 않는 문제로 인해 임시적으로 issue 관련 POST 요청에 대해서만 인터셉터에서 쿠키를 검사하도록 변경