### PR TITLE
[BE] Comment의 최신 Id 값을 가져오는 레포지토리 메소드 오류 해결

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/comment/application/CommentService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/comment/application/CommentService.java
@@ -19,7 +19,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
 
     public Long getNextIdentity() {
-        return Optional.ofNullable(commentRepository.findFirstByOrderByIdDesc())
+        return Optional.ofNullable(commentRepository.findFirstByOrderById_commentIdDesc())
                 .map(comment -> comment.getId().getCommentId() + 1L)
                 .orElseGet(() -> 1L);
     }

--- a/BE/src/main/java/com/codesquad/issuetracker/comment/domain/CommentRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/comment/domain/CommentRepository.java
@@ -7,7 +7,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends CrudRepository<Comment, CommentId> {
-    Comment findFirstByOrderByIdDesc();
+
+    Comment findFirstByOrderById_commentIdDesc();
 
     @Query("SELECT count(comment_id) " +
             "FROM  Comment " +


### PR DESCRIPTION
### 변경한 내용

#123

- 댓글 생성 시 누적되지 않고 가장 마지막 댓글이 변경되는 버그 해결
  - CommentId는 복합키이기 때문에, 가장 최근 Id를 가져오려면 Id.comment_id로 가져와야 하므로 메소드명이 수정됨

