### PR TITLE
[BE] 레코드 시간대를 KST로 변경

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/IssueTrackerApplication.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/IssueTrackerApplication.java
@@ -4,9 +4,17 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @EnableJpaAuditing
 @SpringBootApplication
 public class IssueTrackerApplication {
+
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(IssueTrackerApplication.class, args);

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -56,7 +56,7 @@ spring:
   profiles: production
 
   datasource:
-    url: ENC(xwiWLpHJ7FJPLtOs2pDeyPhXmREXndlkwS1TUniPX4wzZUtU6Jz114Ltm84Hzg4gR1LdnFEe2CPJQ/TxIvUa1/sr1GB38j0wkYo8p4PyNUzAXAs5vRszxHmk41IdEujZRpllGl+fZe5OPo97shn7dfwvB4mUQunTmik76o2JjrQRwMSE1CnyjjV8PXD1XqvmXB9yLNVkiox8MBrNTddw6A==)
+    url: ENC(yjgAelenlAAG8sVCykb+Ngfte7hdJZGji7QIG0M0ZN2v3mahYC/5Z7TlfmtvpWvIl4McOrZHHLkAt0aTygqxwUqz+1Da5HJU8s57r5vyNWTVXtrEAUlKDyiCOct6OL9re94s77d5meg1pwiNRS9lBvZhP4uUME/ipx6vpdPVoIQRHlkEMNC2Vlptbt+GB6vO)
     username: ENC(dWFI/DAXSod1mpm9fOEXhd70DB1D8lOmuYHCA/z7y0CfA5k699XdBzzNQLw5ewHN)
     password: ENC(kBF9VO2QdavUtJyL2oUkx/vjv+AyevUXEQZ5ZCpvDVk5fU7IpGtg5e/R4kh69YeA)
 


### PR DESCRIPTION
### 발생한 문제

#93 

- RDS의 파라미터 옵션으로 Asia/Seoul로 변경하여 DB 내 레코드의 시간은 KST로 저장되지만, 스프링 부트에서 해당 레코드를 꺼내오는 과정에서 UTC로 변경되는 문제.

### 변경한 내용

- 스프링 부트의 TimeZone을 빈 생성한 이후 최초 1번만 Asia/Seoul로 변경하도록 수정
