### PR TITLE
[FE] 이슈 생성 기능 (API 연결)

### DIFF
--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -10,10 +10,13 @@ import useDebounce from "@Hooks/useDebounce";
 
 const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
   const [isRawOpen, setIsRawOpen] = useState(true);
+  const [title, setTitle] = useState("");
   const [rawContent, setRawContent] = useState("");
 
-  const onSetRawContent = (e) => {
-    setRawContent(e.target.value);
+  const onSetTitle = ({ target }) => setTitle(target.value);
+
+  const onSetRawContent = ({ target }) => setRawContent(target.value);
+
   };
 
   return (
@@ -21,7 +24,7 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
       <Wrapper>
         <Avatar src={decodeURIComponent(getCookieValue("avatarUrl"))}></Avatar>
         <CommentGroup>
-          {isIssue && <Title type="text" placeholder="Title" />}
+          {isIssue && <Title type="text" placeholder="Title" onChange={onSetTitle} />}
           <ButtonTab>
             <WriteButton onClick={() => setIsRawOpen(true)} isRawOpen={isRawOpen}>
               Write

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -19,10 +19,11 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
 
   let params = {
     title: title,
-    description: rawContent,
+    content: rawContent,
     assignees: [],
     labels: [],
-    milestonesId: null,
+    milestoneId: null,
+  };
   };
 
   return (

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -17,6 +17,12 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
 
   const onSetRawContent = ({ target }) => setRawContent(target.value);
 
+  let params = {
+    title: title,
+    description: rawContent,
+    assignees: [],
+    labels: [],
+    milestonesId: null,
   };
 
   return (

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -19,7 +19,7 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
   return (
     <>
       <Wrapper>
-        <Avatar src="https://avatars3.githubusercontent.com/u/45891045?s=460&u=8603b06db3cddd4f864bd55455f78c28558dfc8b&v=4"></Avatar>
+        <Avatar src={decodeURIComponent(getCookieValue("avatarUrl"))}></Avatar>
         <CommentGroup>
           {isIssue && <Title type="text" placeholder="Title" />}
           <ButtonTab>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -59,7 +59,7 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
                 Close issue
               </Button>
             )}
-            <Button onClick={onPass}>Submit new issue</Button>
+            <Button onClick={() => submitHandler(params)}>Submit new issue</Button>
           </ButtonWrap>
         </CommentGroup>
       </Wrapper>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -1,12 +1,14 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 
-import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
-
 import Button from "@Style/Button";
 import Avatar from "@Style/Avatar";
 
-const MarkdownInputBox = ({ isIssue, onPass }) => {
+import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
+import getCookieValue from "@Lib/getCookieValue";
+import useDebounce from "@Hooks/useDebounce";
+
+const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
   const [isRawOpen, setIsRawOpen] = useState(true);
   const [rawContent, setRawContent] = useState("");
 
@@ -160,4 +162,4 @@ const CloseIssueIcon = styled.svg`
   margin-right: 5px;
 `;
 
-export default MarkdownInputBox;
+export default CommentInputBox;

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -17,6 +17,8 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
 
   const onSetRawContent = ({ target }) => setRawContent(target.value);
 
+  // const debounceRawContent = useDebounce(rawContent);
+
   let params = {
     title: title,
     content: rawContent,
@@ -24,6 +26,12 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
     labels: [],
     milestoneId: null,
   };
+
+  const isDisabled = () => {
+    if (isIssue && title && rawContent) return false;
+    if (!isIssue && rawContent) return false;
+
+    return true;
   };
 
   return (
@@ -60,7 +68,9 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler }) => {
                 Close issue
               </Button>
             )}
-            <Button onClick={() => submitHandler(params)}>Submit new issue</Button>
+            <Button disabled={isDisabled()} onClick={() => submitHandler(params)}>
+              Submit new issue
+            </Button>
           </ButtonWrap>
         </CommentGroup>
       </Wrapper>

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -3,6 +3,13 @@ import { API_URL } from "@Constants/url";
 
 export const getIssue = () => axios.get(API_URL.issue);
 export const getDetailIssue = (issueId) => axios.get(`${API_URL.issue}${issueId}`);
+export const postIssue = (params) =>
+  axios({
+    url: API_URL.issue,
+    data: params,
+    method: "post",
+    credentials: true,
+  });
 
 export const getMilestone = () => axios.get(API_URL.milestone);
 export const getMilestoneDetail = (milestoneId) => axios.get(`${API_URL.milestone}${milestoneId}`);

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -8,8 +8,12 @@ const GET_ISSUE_SUCCESS = "issue/GET_ISSUE_SUCCESS";
 const GET_DETAIL_ISSUE = "issue/GET_DETAIL_ISSUE";
 const GET_DETAIL_ISSUE_SUCCESS = "issue/GET_DETAIL_ISSUE_SUCCESS";
 
+const POST_ISSUE = "issue/POST_ISSUE";
+const POST_ISSUE_SUCCESS = "issue/POST_ISSUE_SUCCESS";
+
 export const getIssue = createRequestThunk(GET_ISSUE, api.getIssue);
 export const getDetailIssue = createRequestThunk(GET_DETAIL_ISSUE, api.getDetailIssue);
+export const postIssue = createRequestThunk(POST_ISSUE, api.postIssue);
 
 const initialState = {
   issues: null,
@@ -23,6 +27,10 @@ const issue = handleActions(
       issues: action.payload.data.issues,
     }),
     [GET_DETAIL_ISSUE_SUCCESS]: (state, action) => ({
+      ...state,
+      detailIssue: action.payload.data,
+    }),
+    [POST_ISSUE_SUCCESS]: (state, action) => ({
       ...state,
       detailIssue: action.payload.data,
     }),

--- a/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
+++ b/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
@@ -13,6 +13,8 @@ const CreateIssuePage = ({ postIssue, detailIssue, loadingIssue }) => {
 
   const passIssueListPage = () => history.push(`/IssueListPage`);
 
+  const passIssueDetailPage = () => history.push(`/IssueDetailPage/${detailIssue.id}`);
+
   const submitHandler = (params) => {
     (async () => {
       try {
@@ -21,6 +23,7 @@ const CreateIssuePage = ({ postIssue, detailIssue, loadingIssue }) => {
         console.error(e);
       }
     })();
+    if (!loadingIssue && detailIssue) passIssueDetailPage();
   };
 
   return (

--- a/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
+++ b/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
@@ -1,12 +1,14 @@
 import React from "react";
 import styled from "styled-components";
 import { useHistory } from "react-router-dom";
+import { connect } from "react-redux";
 
 import CommentInputBox from "@InputBox/CommentInputBox/CommentInputBox";
 import FilterVerticalList from "@FilterButton/FilterVerticalList";
 import Header from "@Header/Header";
+import { postIssue } from "@Modules/issue";
 
-const CreateIssuePage = () => {
+const CreateIssuePage = ({ postIssue, detailIssue, loadingIssue }) => {
   let history = useHistory();
   const passIssueListPage = () => {
     history.push(`/IssueListPage`);
@@ -44,4 +46,12 @@ const IssueBoxWrapper = styled.div`
   width: 75%;
 `;
 
-export default CreateIssuePage;
+export default connect(
+  ({ issue, loading }) => ({
+    detailIssue: issue.detailIssue,
+    loadingIssue: loading["issue/POST_ISSUE"],
+  }),
+  {
+    postIssue,
+  }
+)(CreateIssuePage);

--- a/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
+++ b/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
@@ -16,7 +16,6 @@ const CreateIssuePage = ({ postIssue, detailIssue, loadingIssue }) => {
   const submitHandler = (params) => {
     (async () => {
       try {
-        console.log(params);
         await postIssue(params);
       } catch (e) {
         console.error(e);

--- a/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
+++ b/FE/src/views/CreateIssuePage/CreateIssuePage.jsx
@@ -10,8 +10,18 @@ import { postIssue } from "@Modules/issue";
 
 const CreateIssuePage = ({ postIssue, detailIssue, loadingIssue }) => {
   let history = useHistory();
-  const passIssueListPage = () => {
-    history.push(`/IssueListPage`);
+
+  const passIssueListPage = () => history.push(`/IssueListPage`);
+
+  const submitHandler = (params) => {
+    (async () => {
+      try {
+        console.log(params);
+        await postIssue(params);
+      } catch (e) {
+        console.error(e);
+      }
+    })();
   };
 
   return (
@@ -20,7 +30,7 @@ const CreateIssuePage = ({ postIssue, detailIssue, loadingIssue }) => {
       <ContentWrapper>
         <Content>
           <IssueBoxWrapper>
-            <CommentInputBox isIssue={true} onPass={passIssueListPage} />
+            <CommentInputBox isIssue onPass={passIssueListPage} submitHandler={submitHandler} />
           </IssueBoxWrapper>
           <FilterVerticalList />
         </Content>

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -53,10 +53,12 @@ const Issue = ({ issue }) => {
             </Text>
             <Text fontSize="sm">by {issue.author.nickname}</Text>
             <Text fontSize="sm">
-              <Milestone>
-                <EventNoteIcon style={{ fontSize: 15 }} />
-                {issue.milestone.title}
-              </Milestone>
+              {issue.milestone && (
+                <Milestone>
+                  <EventNoteIcon style={{ fontSize: 15 }} />
+                  {issue.milestone.title}
+                </Milestone>
+              )}
             </Text>
           </Info>
         </IssueWrapper>


### PR DESCRIPTION
### 구현한 내용

- POST Issue 액션 생성해 connect로 연결
- 이슈 생성 성공하면 Issue Detail page로 이동하도록 라우터 처리

#### 바뀐 내용(충돌 가능성)

- MarkdownInputBox가 파일명과 일치하지 않아 파일명과 동일하게 CommentInputBox로 수정
- CommentInputBox의 title useState 추가
- 이슈, 코멘트에 내용이 없으면 버튼이 disabled되도록 변경

### 미구현 내용

- useDebounce custom hook을 글자수 제한에 써야 하는지 딜레이를 걸어야 하는지 고민이라 적용하지 않고 주석처리 상태
- 필터버튼 내용 (Assignee, labels, milestone)은 현재 params에 null로 담겨 있는 상태 

### 논의 거리

- 이슈 생성을 하다 보니 데이터가 많아지면 리스트 로딩이 오래 걸려서 `페이지네이션 + 스켈레톤 로딩`이 필요하지 않나 싶습니다. 샐리 생각은 어떤지 궁금해요!
- 이슈랑 코멘트에 useDebounce를 적용하면 좋을 것 같은데 어떻게 적용하는 것이 좋을까요?(글자수 제한/회원가입과 같이 딜레이..)

Close #113 