### PR TITLE
[FE] 코멘트 생성/삭제

### DIFF
--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -3,14 +3,35 @@ import styled from "styled-components";
 import TimeAgo from "react-timeago";
 import engStrings from "react-timeago/lib/language-strings/en";
 import buildFormatter from "react-timeago/lib/formatters/buildFormatter";
+import { useParams } from "react-router-dom";
 
 import Text from "@Style/Text";
 import Badge from "@Style/Badge";
 import Avatar from "@Style/Avatar";
 
+import { deleteComment } from "@Modules/issue";
+
 const formatter = buildFormatter(engStrings);
 
-const CommentViewBox = ({ owner, createdAt, content, author }) => {
+const CommentViewBox = ({ key, owner, createdAt, content, author }) => {
+  const { issueId } = useParams();
+
+  const deleteHandler = () => {
+    const fn = async () => {
+      try {
+        await deleteComment({ issueId, key });
+      } catch (e) {
+        console.log(e);
+      }
+    };
+    fn();
+  };
+
+  const onDelete = () => {
+    deleteHandler();
+    window.location.reload();
+  };
+
   return (
     <>
       <Wrapper>
@@ -30,7 +51,9 @@ const CommentViewBox = ({ owner, createdAt, content, author }) => {
                 </Badge>
               )}
               <Text color="gray4">Edit</Text>
-              <Text color="gray4">Delete</Text>
+              <Text color="gray4" onClick={onDelete}>
+                Delete
+              </Text>
             </CommentAction>
           </CommentHeader>
           <CommentContent>{content}</CommentContent>

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -49,7 +49,9 @@ const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHa
               )}
             </CommentAction>
           </CommentHeader>
-          <CommentContent>{content}</CommentContent>
+          <CommentContent>
+            <MarkdownConverted content={content} isComment />
+          </CommentContent>
         </CommentGroup>
       </Wrapper>
     </>

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -42,9 +42,11 @@ const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHa
               <Text color="gray4" isClick>
                 Edit
               </Text>
+              {!owner && (
                 <Text color="gray4" onClick={onDelete} isClick>
                   Delete
                 </Text>
+              )}
             </CommentAction>
           </CommentHeader>
           <CommentContent>{content}</CommentContent>

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -9,26 +9,15 @@ import Text from "@Style/Text";
 import Badge from "@Style/Badge";
 import Avatar from "@Style/Avatar";
 
-import { deleteComment } from "@Modules/issue";
+import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
 
 const formatter = buildFormatter(engStrings);
 
-const CommentViewBox = ({ key, owner, createdAt, content, author }) => {
+const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHandler }) => {
   const { issueId } = useParams();
 
-  const deleteHandler = () => {
-    const fn = async () => {
-      try {
-        await deleteComment({ issueId, key });
-      } catch (e) {
-        console.log(e);
-      }
-    };
-    fn();
-  };
-
   const onDelete = () => {
-    deleteHandler();
+    deleteHandler({ issueId, commentId });
     window.location.reload();
   };
 

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -39,10 +39,12 @@ const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHa
                   Owner
                 </Badge>
               )}
-              <Text color="gray4">Edit</Text>
-              <Text color="gray4" onClick={onDelete}>
-                Delete
+              <Text color="gray4" isClick>
+                Edit
               </Text>
+                <Text color="gray4" onClick={onDelete} isClick>
+                  Delete
+                </Text>
             </CommentAction>
           </CommentHeader>
           <CommentContent>{content}</CommentContent>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -34,9 +34,14 @@ const MarkdownInputBox = ({ isIssue, onPass }) => {
           </CommentContent>
           <ButtonWrap isIssue={isIssue}>
             {isIssue ? (
-              <Button backgroundColor="white" color="black" borderColor="white" onClick={onPass}>
-                Cancel
-              </Button>
+              <>
+                <Button backgroundColor="white" color="black" borderColor="white" onClick={onPass}>
+                  Cancel
+                </Button>
+                <Button onClick={onPass} disabled={titleContent ? false : true}>
+                  Submit new issue
+                </Button>
+              </>
             ) : (
               <Button backgroundColor="white" color="black" style={{ marginRight: "5px" }}>
                 <CloseIssueIcon>
@@ -48,7 +53,6 @@ const MarkdownInputBox = ({ isIssue, onPass }) => {
                 Close issue
               </Button>
             )}
-            <Button onClick={onPass}>Submit new issue</Button>
           </ButtonWrap>
         </CommentGroup>
       </Wrapper>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -69,15 +69,20 @@ const MarkdownInputBox = ({ isIssue, onPass }) => {
                 </Button>
               </>
             ) : (
-              <Button backgroundColor="white" color="black" style={{ marginRight: "5px" }}>
-                <CloseIssueIcon>
-                  <path
-                    fillRule="evenodd"
-                    d="M1.5 8a6.5 6.5 0 0110.65-5.003.75.75 0 00.959-1.153 8 8 0 102.592 8.33.75.75 0 10-1.444-.407A6.5 6.5 0 011.5 8zM8 12a1 1 0 100-2 1 1 0 000 2zm0-8a.75.75 0 01.75.75v3.5a.75.75 0 11-1.5 0v-3.5A.75.75 0 018 4zm4.78 4.28l3-3a.75.75 0 00-1.06-1.06l-2.47 2.47-.97-.97a.749.749 0 10-1.06 1.06l1.5 1.5a.75.75 0 001.06 0z"
-                  ></path>
-                </CloseIssueIcon>
-                Close issue
-              </Button>
+              <>
+                <Button backgroundColor="white" color="black" style={{ marginRight: "5px" }}>
+                  <CloseIssueIcon>
+                    <path
+                      fillRule="evenodd"
+                      d="M1.5 8a6.5 6.5 0 0110.65-5.003.75.75 0 00.959-1.153 8 8 0 102.592 8.33.75.75 0 10-1.444-.407A6.5 6.5 0 011.5 8zM8 12a1 1 0 100-2 1 1 0 000 2zm0-8a.75.75 0 01.75.75v3.5a.75.75 0 11-1.5 0v-3.5A.75.75 0 018 4zm4.78 4.28l3-3a.75.75 0 00-1.06-1.06l-2.47 2.47-.97-.97a.749.749 0 10-1.06 1.06l1.5 1.5a.75.75 0 001.06 0z"
+                    ></path>
+                  </CloseIssueIcon>
+                  Close issue
+                </Button>
+                <Button onClick={onComment} disabled={rawContent ? false : true}>
+                  Comment
+                </Button>
+              </>
             )}
           </ButtonWrap>
         </CommentGroup>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -6,9 +6,8 @@ import Button from "@Style/Button";
 import Avatar from "@Style/Avatar";
 
 import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
-import { postComment } from "@Modules/issue";
 
-const MarkdownInputBox = ({ isIssue, onPass }) => {
+const MarkdownInputBox = ({ isIssue, onPass, postHandler }) => {
   const { issueId } = useParams();
 
   const [isRawOpen, setIsRawOpen] = useState(true);
@@ -23,19 +22,9 @@ const MarkdownInputBox = ({ isIssue, onPass }) => {
     setTitleContent(e.target.value);
   };
 
-  const postHandler = () => {
-    const fn = async () => {
-      try {
-        await postComment({ issueId, rawContent });
-      } catch (e) {
-        console.log(e);
-      }
-    };
-    fn();
-  };
-
   const onComment = () => {
-    postHandler();
+    const params = rawContent;
+    postHandler({ issueId, params });
     window.location.reload();
   };
 

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -1,12 +1,16 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-
-import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
+import { useParams } from "react-router-dom";
 
 import Button from "@Style/Button";
 import Avatar from "@Style/Avatar";
 
+import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
+import { postComment } from "@Modules/issue";
+
 const MarkdownInputBox = ({ isIssue, onPass }) => {
+  const { issueId } = useParams();
+
   const [isRawOpen, setIsRawOpen] = useState(true);
   const [rawContent, setRawContent] = useState("");
   const [titleContent, setTitleContent] = useState("");
@@ -18,6 +22,24 @@ const MarkdownInputBox = ({ isIssue, onPass }) => {
   const onSetTitleContent = (e) => {
     setTitleContent(e.target.value);
   };
+
+  const postHandler = () => {
+    const params = rawContent;
+    const fn = async () => {
+      try {
+        await postComment({ issueId, params });
+      } catch (e) {
+        console.log(e);
+      }
+    };
+    fn();
+  };
+
+  const onComment = () => {
+    postHandler();
+    window.location.reload();
+  };
+
   return (
     <>
       <Wrapper>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -24,10 +24,9 @@ const MarkdownInputBox = ({ isIssue, onPass }) => {
   };
 
   const postHandler = () => {
-    const params = rawContent;
     const fn = async () => {
       try {
-        await postComment({ issueId, params });
+        await postComment({ issueId, rawContent });
       } catch (e) {
         console.log(e);
       }

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -9,17 +9,21 @@ import Avatar from "@Style/Avatar";
 const MarkdownInputBox = ({ isIssue, onPass }) => {
   const [isRawOpen, setIsRawOpen] = useState(true);
   const [rawContent, setRawContent] = useState("");
+  const [titleContent, setTitleContent] = useState("");
 
   const onSetRawContent = (e) => {
     setRawContent(e.target.value);
   };
 
+  const onSetTitleContent = (e) => {
+    setTitleContent(e.target.value);
+  };
   return (
     <>
       <Wrapper>
         <Avatar src="https://avatars3.githubusercontent.com/u/45891045?s=460&u=8603b06db3cddd4f864bd55455f78c28558dfc8b&v=4"></Avatar>
         <CommentGroup>
-          {isIssue && <Title type="text" placeholder="Title" />}
+          {isIssue && <Title type="text" placeholder="Title" onChange={onSetTitleContent} />}
           <ButtonTab>
             <WriteButton onClick={() => setIsRawOpen(true)} isRawOpen={isRawOpen}>
               Write

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -23,7 +23,7 @@ const MarkdownInputBox = ({ isIssue, onPass, postHandler }) => {
   };
 
   const onComment = () => {
-    const params = rawContent;
+    const params = { content: rawContent };
     postHandler({ issueId, params });
     window.location.reload();
   };

--- a/FE/src/components/InputBox/CommentInputBox/MarkdownConverted.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/MarkdownConverted.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import MarkdownIt from "markdown-it";
 
-const MarkdownConverted = ({ content, isRawOpen }) => {
+const MarkdownConverted = ({ content, isRawOpen, isComment }) => {
   const text = content ? content : "Nothing to preview";
   const mdParser = new MarkdownIt({
     html: true,
@@ -13,7 +13,7 @@ const MarkdownConverted = ({ content, isRawOpen }) => {
 
   const convertedText = mdParser.render(text);
 
-  return <ConvertedText dangerouslySetInnerHTML={{ __html: convertedText }} isRawOpen={isRawOpen} />;
+  return <ConvertedText dangerouslySetInnerHTML={{ __html: convertedText }} isRawOpen={isRawOpen} isComment={isComment} />;
 };
 
 const ConvertedText = styled.div`
@@ -21,7 +21,7 @@ const ConvertedText = styled.div`
   display: ${(props) => (props.isRawOpen ? "none" : "block")};
   width: -webkit-fill-available;
   height: 100%;
-  min-height: 200px;
+  min-height: ${(props) => (props.isComment ? "" : "200px")};
   & pre {
     background-color: #f6f8fa;
     padding: 5px;

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -4,6 +4,7 @@ import { API_URL } from "@Constants/url";
 export const getIssue = () => axios.get(API_URL.issue);
 export const getDetailIssue = (issueId) => axios.get(`${API_URL.issue}${issueId}`);
 export const postComment = ({ issueId, params }) => axios.post(`${API_URL.issue}${issueId}/comments`, params);
+export const deleteComment = ({ issueId, commentId }) => axios.delete(`${API_URL.issue}${issueId}/comments/${commentId}`);
 
 export const getMilestone = () => axios.get(API_URL.milestone);
 export const getMilestoneDetail = (milestoneId) => axios.get(`${API_URL.milestone}${milestoneId}`);

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -3,6 +3,7 @@ import { API_URL } from "@Constants/url";
 
 export const getIssue = () => axios.get(API_URL.issue);
 export const getDetailIssue = (issueId) => axios.get(`${API_URL.issue}${issueId}`);
+export const postComment = ({ issueId, params }) => axios.post(`${API_URL.issue}${issueId}/comments`, params);
 
 export const getMilestone = () => axios.get(API_URL.milestone);
 export const getMilestoneDetail = (milestoneId) => axios.get(`${API_URL.milestone}${milestoneId}`);

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -9,9 +9,12 @@ const GET_DETAIL_ISSUE = "issue/GET_DETAIL_ISSUE";
 const GET_DETAIL_ISSUE_SUCCESS = "issue/GET_DETAIL_ISSUE_SUCCESS";
 
 const POST_COMMENT = "issue/POST_COMMENT";
+const DELETE_COMMENT = "issue/DELETE_COMMENT";
+
 export const getIssue = createRequestThunk(GET_ISSUE, api.getIssue);
 export const getDetailIssue = createRequestThunk(GET_DETAIL_ISSUE, api.getDetailIssue);
 export const postComment = createRequestThunk(POST_COMMENT, api.postComment);
+export const deleteComment = createRequestThunk(DELETE_COMMENT, api.deleteComment);
 
 const initialState = {
   issues: null,

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -8,8 +8,10 @@ const GET_ISSUE_SUCCESS = "issue/GET_ISSUE_SUCCESS";
 const GET_DETAIL_ISSUE = "issue/GET_DETAIL_ISSUE";
 const GET_DETAIL_ISSUE_SUCCESS = "issue/GET_DETAIL_ISSUE_SUCCESS";
 
+const POST_COMMENT = "issue/POST_COMMENT";
 export const getIssue = createRequestThunk(GET_ISSUE, api.getIssue);
 export const getDetailIssue = createRequestThunk(GET_DETAIL_ISSUE, api.getDetailIssue);
+export const postComment = createRequestThunk(POST_COMMENT, api.postComment);
 
 const initialState = {
   issues: null,

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -7,11 +7,20 @@ import FilterVerticalList from "@FilterButton/FilterVerticalList";
 import CommentInputBox from "@InputBox/CommentInputBox/CommentInputBox";
 import Header from "@Header/Header";
 import CommentViewBox from "@CommentViewBox/CommentViewBox";
-import { getDetailIssue } from "@Modules/issue";
+import { getDetailIssue, postComment, deleteComment } from "@Modules/issue";
 
-const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue }) => {
+const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, postComment, deleteComment }) => {
   const { issueId } = useParams();
 
+  const postHandler = ({ issueId, params }) => {
+    (async () => {
+      try {
+        await postComment({ issueId, params });
+      } catch (e) {
+        console.log(e);
+      }
+    })();
+  };
   const CommentList = () => (
     <>
       {!loadingDetailIssue &&
@@ -52,7 +61,7 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue }) =>
               <CommentViewBox owner createdAt={detailIssue.createdAt} content={detailIssue.content} author={detailIssue.author} />
             )}
             <CommentList />
-            <CommentInputBox />
+            <CommentInputBox postHandler={postHandler} />
           </CommentViewBoxWrapper>
           <FilterVerticalList />
         </Content>
@@ -89,5 +98,7 @@ export default connect(
   }),
   {
     getDetailIssue,
+    postComment,
+    deleteComment,
   }
 )(IssueDetailPage);

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -21,6 +21,17 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
       }
     })();
   };
+
+  const deleteHandler = ({ issueId, commentId }) => {
+    (async () => {
+      try {
+        await deleteComment({ issueId, commentId });
+      } catch (e) {
+        console.log(e);
+      }
+    })();
+  };
+
   const CommentList = () => (
     <>
       {!loadingDetailIssue &&
@@ -35,7 +46,16 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
             user,
           } = comment;
 
-          return <CommentViewBox key={commentId} createdAt={createdAt} content={content} author={user} />;
+          return (
+            <CommentViewBox
+              key={commentId}
+              commentId={commentId}
+              createdAt={createdAt}
+              content={content}
+              author={user}
+              deleteHandler={deleteHandler}
+            />
+          );
         })}
     </>
   );

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -73,7 +73,7 @@ const Issue = ({ issue }) => {
           </>
         )}
         <CommentWrapper>
-          {issue.numberOfComment && (
+          {issue.numberOfComment > 0 && (
             <>
               <ChatBubbleOutlineIcon style={{ fontSize: 15 }} />
               {issue.numberOfComment}

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -53,10 +53,14 @@ const Issue = ({ issue }) => {
             </Text>
             <Text fontSize="sm">by {issue.author.nickname}</Text>
             <Text fontSize="sm">
-              <Milestone>
-                <EventNoteIcon style={{ fontSize: 15 }} />
-                {issue.milestone.title}
-              </Milestone>
+              {issue.milestone && (
+                <>
+                  <Milestone>
+                    <EventNoteIcon style={{ fontSize: 15 }} />
+                    {issue.milestone.title}
+                  </Milestone>
+                </>
+              )}
             </Text>
           </Info>
         </IssueWrapper>


### PR DESCRIPTION
### 구현한 내용

- 코멘트 생성/삭제 api 연결
- 이슈 디테일 페이지에서 post handler, delete handler 구현 후 각각 comment input box와 comment view box에 props로 전달
- 이슈 디테일 페이지의 코멘트 마크다운 적용되어 보이도록 수정
- comment input box 의 submit new issue 버튼과 comment 버튼으로 분리
- comment input box 제목과 raw content로 버튼 disabled 설정
- 코멘트 edit/delete 글자에 커서 모양 설정
- owner 코멘트의 경우 delete 버튼 삭제