### PR TITLE
[FE] 코멘트 수정 기능

### DIFF
--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -26,7 +26,7 @@ const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHa
       <Wrapper>
         <Avatar src={author.avatarUrl}></Avatar>
         <CommentGroup>
-          <CommentHeader owner={owner ? true : false}>
+          <CommentHeader owner={owner}>
             <CommentText>
               <Text fontWeight="extraBold">{author.nickname}</Text>
               <Text color="gray4">

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -13,13 +13,15 @@ import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
 
 const formatter = buildFormatter(engStrings);
 
-const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHandler }) => {
+const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHandler, editClickHandler }) => {
   const { issueId } = useParams();
 
   const onDelete = () => {
     deleteHandler({ issueId, commentId });
     window.location.reload();
   };
+
+  const editClick = () => editClickHandler(commentId);
 
   return (
     <>
@@ -39,7 +41,7 @@ const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHa
                   Owner
                 </Badge>
               )}
-              <Text color="gray4" isClick>
+              <Text color="gray4" isClick onClick={editClick}>
                 Edit
               </Text>
               {!owner && (

--- a/FE/src/components/CommentViewBox/CommentViewBox.jsx
+++ b/FE/src/components/CommentViewBox/CommentViewBox.jsx
@@ -24,7 +24,7 @@ const CommentViewBox = ({ commentId, owner, createdAt, content, author, deleteHa
   return (
     <>
       <Wrapper>
-        <Avatar src={owner ? author.avatarUrl : author.avatar_url}></Avatar>
+        <Avatar src={author.avatarUrl}></Avatar>
         <CommentGroup>
           <CommentHeader owner={owner ? true : false}>
             <CommentText>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -15,11 +15,15 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler }) => {
   const [rawContent, setRawContent] = useState(editContent ? editContent : "");
   const [titleContent, setTitleContent] = useState("");
 
+  // const debounceRawContent = useDebounce(rawContent);
+
   const onSetTitleContent = ({ target }) => setTitleContent(target.value);
 
   const onSetRawContent = ({ target }) => setRawContent(target.value);
 
-  // const debounceRawContent = useDebounce(rawContent);
+  const rawOpen = () => setIsRawOpen(true);
+
+  const markdownOpen = () => setIsRawOpen(false);
 
   let params = {
     title: titleContent,
@@ -42,10 +46,10 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler }) => {
         <CommentGroup>
           {isIssue && <Title type="text" placeholder="Title" onChange={onSetTitleContent} />}
           <ButtonTab>
-            <WriteButton onClick={() => setIsRawOpen(true)} isRawOpen={isRawOpen}>
+            <WriteButton onClick={rawOpen} isRawOpen={isRawOpen}>
               Write
             </WriteButton>
-            <PreviewButton onClick={() => setIsRawOpen(false)} isRawOpen={isRawOpen}>
+            <PreviewButton onClick={markdownOpen} isRawOpen={isRawOpen}>
               Preview
             </PreviewButton>
           </ButtonTab>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
 
@@ -14,6 +14,7 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentI
   const [isRawOpen, setIsRawOpen] = useState(true);
   const [rawContent, setRawContent] = useState(editContent ? editContent : "");
   const [titleContent, setTitleContent] = useState("");
+  const inputRef = useRef();
 
   // const debounceRawContent = useDebounce(rawContent);
 
@@ -39,6 +40,14 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentI
     window.location.reload();
   };
 
+  useEffect(() => {
+    if (editContent) {
+      inputRef.current.focus();
+      inputRef.current.selectionStart = inputRef.current.value.length;
+      inputRef.current.selectionEnd = inputRef.current.value.length;
+    }
+  }, []);
+
   return (
     <>
       <Wrapper>
@@ -54,7 +63,14 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentI
             </PreviewButton>
           </ButtonTab>
           <CommentContent>
-            <RawContent type="text" onChange={onSetRawContent} placeholder="Leave a comment" isRawOpen={isRawOpen} />
+            <RawContent
+              type="text"
+              ref={inputRef}
+              defaultValue={editContent}
+              placeholder="Leave a comment"
+              onChange={onSetRawContent}
+              isRawOpen={isRawOpen}
+            />
             <MarkdownConverted content={rawContent} isRawOpen={isRawOpen} />
           </CommentContent>
           <ButtonWrap isIssue={isIssue}>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -9,7 +9,7 @@ import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
 import getCookieValue from "@Lib/getCookieValue";
 import useDebounce from "@Hooks/useDebounce";
 
-const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler }) => {
+const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentId, editContent, author }) => {
   const { issueId } = useParams();
   const [isRawOpen, setIsRawOpen] = useState(true);
   const [rawContent, setRawContent] = useState(editContent ? editContent : "");
@@ -42,7 +42,7 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler }) => {
   return (
     <>
       <Wrapper>
-        <Avatar src={decodeURIComponent(getCookieValue("avatarUrl"))}></Avatar>
+        <Avatar src={author ? author.avatarUrl : decodeURIComponent(getCookieValue("avatarUrl"))}></Avatar>
         <CommentGroup>
           {isIssue && <Title type="text" placeholder="Title" onChange={onSetTitleContent} />}
           <ButtonTab>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -26,13 +26,15 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentI
 
   const markdownOpen = () => setIsRawOpen(false);
 
-  let params = {
+  const submitParams = {
     title: titleContent,
     content: rawContent,
     assignees: [],
     labels: [],
     milestoneId: null,
   };
+
+  const editParams = { content: rawContent };
 
   const onComment = () => {
     const params = { content: rawContent };

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -74,7 +74,7 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler }) => {
                   </CloseIssueIcon>
                   Close issue
                 </Button>
-                <Button onClick={onComment} disabled={rawContent ? false : true}>
+                <Button onClick={onComment} disabled={!rawContent}>
                   Comment
                 </Button>
               </>

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -36,6 +36,10 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentI
 
   const editParams = { content: rawContent };
 
+  const submiClicktHandler = () => submitHandler(submitParams);
+
+  const editClickHandler = () => onPass({ issueId, commentId, params: editParams });
+
   const onComment = () => {
     const params = { content: rawContent };
     postHandler({ issueId, params });

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -12,7 +12,7 @@ import useDebounce from "@Hooks/useDebounce";
 const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler }) => {
   const { issueId } = useParams();
   const [isRawOpen, setIsRawOpen] = useState(true);
-  const [rawContent, setRawContent] = useState("");
+  const [rawContent, setRawContent] = useState(editContent ? editContent : "");
   const [titleContent, setTitleContent] = useState("");
 
   const onSetTitleContent = ({ target }) => setTitleContent(target.value);

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -80,13 +80,13 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentI
             <MarkdownConverted content={rawContent} isRawOpen={isRawOpen} />
           </CommentContent>
           <ButtonWrap isIssue={isIssue}>
-            {isIssue ? (
+            {isIssue || editContent ? (
               <>
                 <Button backgroundColor="white" color="black" borderColor="white" onClick={onPass}>
                   Cancel
                 </Button>
-                <Button onClick={onPass} disabled={titleContent ? false : true} onClick={() => submitHandler(params)}>
-                  Submit new issue
+                <Button disabled={isIssue ? !titleContent : !rawContent} onClick={isIssue ? submiClicktHandler : editClickHandler}>
+                  {isIssue ? "Submit new issue" : "Update comment"}
                 </Button>
               </>
             ) : (

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -3,8 +3,6 @@ import { API_URL } from "@Constants/url";
 
 export const getIssue = () => axios.get(API_URL.issue);
 export const getDetailIssue = (issueId) => axios.get(`${API_URL.issue}${issueId}`);
-export const postComment = ({ issueId, params }) => axios.post(`${API_URL.issue}${issueId}/comments`, params);
-export const deleteComment = ({ issueId, commentId }) => axios.delete(`${API_URL.issue}${issueId}/comments/${commentId}`);
 export const postIssue = (params) =>
   axios({
     url: API_URL.issue,
@@ -12,6 +10,9 @@ export const postIssue = (params) =>
     method: "post",
     credentials: true,
   });
+export const postComment = ({ issueId, params }) => axios.post(`${API_URL.issue}${issueId}/comments`, params);
+export const putComment = ({ issueId, commentId, params }) => axios.put(`${API_URL.issue}${issueId}/comments/${commentId}`, params);
+export const deleteComment = ({ issueId, commentId }) => axios.delete(`${API_URL.issue}${issueId}/comments/${commentId}`);
 
 export const getMilestone = () => axios.get(API_URL.milestone);
 export const getMilestoneDetail = (milestoneId) => axios.get(`${API_URL.milestone}${milestoneId}`);

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -8,17 +8,22 @@ const GET_ISSUE_SUCCESS = "issue/GET_ISSUE_SUCCESS";
 const GET_DETAIL_ISSUE = "issue/GET_DETAIL_ISSUE";
 const GET_DETAIL_ISSUE_SUCCESS = "issue/GET_DETAIL_ISSUE_SUCCESS";
 
-const POST_COMMENT = "issue/POST_COMMENT";
-const DELETE_COMMENT = "issue/DELETE_COMMENT";
-
 const POST_ISSUE = "issue/POST_ISSUE";
 const POST_ISSUE_SUCCESS = "issue/POST_ISSUE_SUCCESS";
 
+const POST_COMMENT = "issue/POST_COMMENT";
+
+const PUT_COMMENT = "issue/PUT_COMMENT";
+const PUT_COMMENT_SUCCESS = "issue/PUT_COMMENT_SUCCESS";
+
+const DELETE_COMMENT = "issue/DELETE_COMMENT";
+
 export const getIssue = createRequestThunk(GET_ISSUE, api.getIssue);
 export const getDetailIssue = createRequestThunk(GET_DETAIL_ISSUE, api.getDetailIssue);
-export const postComment = createRequestThunk(POST_COMMENT, api.postComment);
-export const deleteComment = createRequestThunk(DELETE_COMMENT, api.deleteComment);
 export const postIssue = createRequestThunk(POST_ISSUE, api.postIssue);
+export const postComment = createRequestThunk(POST_COMMENT, api.postComment);
+export const putComment = createRequestThunk(PUT_COMMENT, api.putComment);
+export const deleteComment = createRequestThunk(DELETE_COMMENT, api.deleteComment);
 
 const initialState = {
   issues: null,

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -7,9 +7,9 @@ import FilterVerticalList from "@FilterButton/FilterVerticalList";
 import CommentInputBox from "@InputBox/CommentInputBox/CommentInputBox";
 import Header from "@Header/Header";
 import CommentViewBox from "@CommentViewBox/CommentViewBox";
-import { getDetailIssue, postComment, deleteComment } from "@Modules/issue";
+import { getDetailIssue, postComment, putComment, deleteComment } from "@Modules/issue";
 
-const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, postComment, deleteComment }) => {
+const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, postComment, putComment, deleteComment }) => {
   const { issueId } = useParams();
 
   const postHandler = ({ issueId, params }) => {
@@ -119,6 +119,7 @@ export default connect(
   {
     getDetailIssue,
     postComment,
+    putComment,
     deleteComment,
   }
 )(IssueDetailPage);

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -25,6 +25,16 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
 
   const editClickHandler = (commentId) => setEditCommentInfo({ isEdit: true, editComment: commentId });
 
+  const editCommentHandler = ({ issueId, commentId, params }) => {
+    (async () => {
+      try {
+        await putComment({ issueId, commentId, params });
+      } catch (e) {
+        console.log(e);
+      }
+    })();
+  };
+
   const deleteHandler = ({ issueId, commentId }) => {
     (async () => {
       try {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useParams } from "react-router-dom";
 import { connect } from "react-redux";
@@ -11,6 +11,7 @@ import { getDetailIssue, postComment, putComment, deleteComment } from "@Modules
 
 const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, postComment, putComment, deleteComment }) => {
   const { issueId } = useParams();
+  const [editCommentInfo, setEditCommentInfo] = useState({ isEdit: false, editComment: null });
 
   const postHandler = ({ issueId, params }) => {
     (async () => {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -33,6 +33,8 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
         console.log(e);
       }
     })();
+
+    setEditCommentInfo({ isEdit: false, editComment: commentId });
   };
 
   const deleteHandler = ({ issueId, commentId }) => {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -35,6 +35,12 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
     })();
 
     setEditCommentInfo({ isEdit: false, editComment: commentId });
+
+    detailIssue.comments.forEach(({ comment }) => {
+      if (comment.id.commentId === commentId) {
+        comment.content = params.content;
+      }
+    });
   };
 
   const deleteHandler = ({ issueId, commentId }) => {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -13,6 +13,8 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
   const { issueId } = useParams();
   const [editCommentInfo, setEditCommentInfo] = useState({ isEdit: false, editComment: null });
 
+  const checkEditCommentInfo = (commentId) => editCommentInfo.isEdit && editCommentInfo.editComment === commentId;
+
   const postHandler = ({ issueId, params }) => {
     (async () => {
       try {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -23,6 +23,8 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
     })();
   };
 
+  const editClickHandler = (commentId) => setEditCommentInfo({ isEdit: true, editComment: commentId });
+
   const deleteHandler = ({ issueId, commentId }) => {
     (async () => {
       try {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -69,13 +69,16 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
             user,
           } = comment;
 
-          return (
+          return checkEditCommentInfo(commentId) ? (
+            <CommentInputBox key={commentId} commentId={commentId} editContent={content} author={user} onPass={editCommentHandler} />
+          ) : (
             <CommentViewBox
               key={commentId}
               commentId={commentId}
               createdAt={createdAt}
               content={content}
               author={user}
+              editClickHandler={editClickHandler}
               deleteHandler={deleteHandler}
             />
           );

--- a/FE/src/views/LoginPage/LoginPage.jsx
+++ b/FE/src/views/LoginPage/LoginPage.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import GitHubIcon from "@material-ui/icons/GitHub";
 import { useHistory } from "react-router-dom";
 import { connect } from "react-redux";
+import GitHubIcon from "@material-ui/icons/GitHub";
 
 import Text from "@Style/Text";
 import Button from "@Style/Button";

--- a/FE/webpack.dev.js
+++ b/FE/webpack.dev.js
@@ -13,6 +13,7 @@ module.exports = merge(common, {
     inline: true,
     port: 3000,
     hot: true,
+    open: true,
     publicPath: "/",
   },
 

--- a/FE/webpack.prod.js
+++ b/FE/webpack.prod.js
@@ -22,6 +22,7 @@ module.exports = merge(common, {
       },
     },
   },
+
   performance: {
     hints: false,
     maxEntrypointSize: 512000,


### PR DESCRIPTION
### 구현한 내용

- PUT Comment 액션 생성해 connect로 연결
- 코멘트 수정 성공하면 해당 id의 코멘트만 변경되어 재로딩하지 않도록 처리

![2020-07-14 17 14 44](https://user-images.githubusercontent.com/30427711/87401912-c3bfae80-c5f5-11ea-988f-52de89a44a9f.gif)


### 논의 거리

- 이슈랑 코멘트에 useDebounce를 적용하면 좋을 것 같은데 어떻게 적용하는 것이 좋을까요?(글자수 제한/회원가입과 같이 딜레이..)
- 코멘트 수정 부분을 하다 보니 생성이나 삭제를 할 때 리로드를 하면 화면이 깜박거리는게 불필요하다는 생각이 들어요! 실시간 데이터 로딩은 사용자가 새로고침했을 때 로딩되게 해도 되지 않을까 싶은데 어떠신가요?? 

Close #114 

---
댓글로 논의하면 좋을 것 같아요!