### PR TITLE
[FE] 이슈 Open/Close 기능

### DIFF
--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -38,6 +38,8 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, changeIs
 
   const editParams = { content: rawContent };
 
+  const changeIssueClickHandler = () => changeIssueOpenClose();
+
   const submiClicktHandler = () => submitHandler(submitParams);
 
   const editClickHandler = () => onPass({ issueId, commentId, params: editParams });
@@ -93,14 +95,18 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, changeIs
               </>
             ) : (
               <>
-                <Button backgroundColor="white" color="black" style={{ marginRight: "5px" }}>
-                  <CloseIssueIcon>
-                    <path
-                      fillRule="evenodd"
-                      d="M1.5 8a6.5 6.5 0 0110.65-5.003.75.75 0 00.959-1.153 8 8 0 102.592 8.33.75.75 0 10-1.444-.407A6.5 6.5 0 011.5 8zM8 12a1 1 0 100-2 1 1 0 000 2zm0-8a.75.75 0 01.75.75v3.5a.75.75 0 11-1.5 0v-3.5A.75.75 0 018 4zm4.78 4.28l3-3a.75.75 0 00-1.06-1.06l-2.47 2.47-.97-.97a.749.749 0 10-1.06 1.06l1.5 1.5a.75.75 0 001.06 0z"
-                    ></path>
-                  </CloseIssueIcon>
-                  Close issue
+                <Button backgroundColor="white" color="black" style={{ marginRight: "5px" }} onClick={changeIssueClickHandler}>
+                  {checkIssueClose() ? (
+                    ""
+                  ) : (
+                    <CloseIssueIcon>
+                      <path
+                        fillRule="evenodd"
+                        d="M1.5 8a6.5 6.5 0 0110.65-5.003.75.75 0 00.959-1.153 8 8 0 102.592 8.33.75.75 0 10-1.444-.407A6.5 6.5 0 011.5 8zM8 12a1 1 0 100-2 1 1 0 000 2zm0-8a.75.75 0 01.75.75v3.5a.75.75 0 11-1.5 0v-3.5A.75.75 0 018 4zm4.78 4.28l3-3a.75.75 0 00-1.06-1.06l-2.47 2.47-.97-.97a.749.749 0 10-1.06 1.06l1.5 1.5a.75.75 0 001.06 0z"
+                      ></path>
+                    </CloseIssueIcon>
+                  )}
+                  {checkIssueClose() ? "Reopen issue" : "Close issue"}
                 </Button>
                 <Button onClick={onComment} disabled={!rawContent}>
                   Comment

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -9,7 +9,7 @@ import MarkdownConverted from "@InputBox/CommentInputBox/MarkdownConverted";
 import getCookieValue from "@Lib/getCookieValue";
 import useDebounce from "@Hooks/useDebounce";
 
-const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentId, editContent, author }) => {
+const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, changeIssueOpenClose, commentId, editContent, author, issueCloseInfo }) => {
   const { issueId } = useParams();
   const [isRawOpen, setIsRawOpen] = useState(true);
   const [rawContent, setRawContent] = useState(editContent ? editContent : "");
@@ -25,6 +25,8 @@ const CommentInputBox = ({ isIssue, onPass, submitHandler, postHandler, commentI
   const rawOpen = () => setIsRawOpen(true);
 
   const markdownOpen = () => setIsRawOpen(false);
+
+  const checkIssueClose = () => issueCloseInfo.isClose && issueCloseInfo.issueId === issueId;
 
   const submitParams = {
     title: titleContent,

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -3,6 +3,7 @@ import { API_URL } from "@Constants/url";
 
 export const getIssue = () => axios.get(API_URL.issue);
 export const getDetailIssue = (issueId) => axios.get(`${API_URL.issue}${issueId}`);
+export const changeIssueStatus = (issueId) => axios.patch(`${API_URL.issue}/${issueId}`);
 export const postIssue = (params) =>
   axios({
     url: API_URL.issue,

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -8,6 +8,9 @@ const GET_ISSUE_SUCCESS = "issue/GET_ISSUE_SUCCESS";
 const GET_DETAIL_ISSUE = "issue/GET_DETAIL_ISSUE";
 const GET_DETAIL_ISSUE_SUCCESS = "issue/GET_DETAIL_ISSUE_SUCCESS";
 
+const CHANGE_ISSUE_STATUS = "issue/CHANGE_ISSUE_STATUS";
+const CHANGE_ISSUE_STATUS_SUCCESS = "issue/CHANGE_ISSUE_STATUS_SUCCESS";
+
 const POST_ISSUE = "issue/POST_ISSUE";
 const POST_ISSUE_SUCCESS = "issue/POST_ISSUE_SUCCESS";
 
@@ -21,6 +24,7 @@ const DELETE_COMMENT = "issue/DELETE_COMMENT";
 export const getIssue = createRequestThunk(GET_ISSUE, api.getIssue);
 export const getDetailIssue = createRequestThunk(GET_DETAIL_ISSUE, api.getDetailIssue);
 export const postIssue = createRequestThunk(POST_ISSUE, api.postIssue);
+export const changeIssueStatus = createRequestThunk(CHANGE_ISSUE_STATUS, api.changeIssueStatus);
 export const postComment = createRequestThunk(POST_COMMENT, api.postComment);
 export const putComment = createRequestThunk(PUT_COMMENT, api.putComment);
 export const deleteComment = createRequestThunk(DELETE_COMMENT, api.deleteComment);
@@ -28,6 +32,7 @@ export const deleteComment = createRequestThunk(DELETE_COMMENT, api.deleteCommen
 const initialState = {
   issues: null,
   detailIssue: null,
+  statusCode: null,
 };
 
 const issue = handleActions(
@@ -43,6 +48,10 @@ const issue = handleActions(
     [POST_ISSUE_SUCCESS]: (state, action) => ({
       ...state,
       detailIssue: action.payload.data,
+    }),
+    [CHANGE_ISSUE_STATUS_SUCCESS]: (state, action) => ({
+      ...state,
+      statusCode: action.payload.status,
     }),
   },
   initialState

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -34,7 +34,7 @@ const IssueDetailPage = ({
       }
     })();
 
-    setIssueCloseInfo({ isClose: !issueCloseInfo.isClose, issueId: issueId });
+    setIssueCloseInfo({ isClose: !issueCloseInfo.isClose, issueId });
   };
 
   const postHandler = ({ issueId, params }) => {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -114,6 +114,8 @@ const IssueDetailPage = ({
         console.log(e);
       }
     })();
+
+    if (detailIssue) setIssueCloseInfo({ isClose: detailIssue.isOpen, issueId });
   }, []);
 
   return (

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -21,8 +21,21 @@ const IssueDetailPage = ({
 }) => {
   const { issueId } = useParams();
   const [editCommentInfo, setEditCommentInfo] = useState({ isEdit: false, editComment: null });
+  const [issueCloseInfo, setIssueCloseInfo] = useState({ isClose: false, issueId: null });
 
   const checkEditCommentInfo = (commentId) => editCommentInfo.isEdit && editCommentInfo.editComment === commentId;
+
+  const changeIssueOpenClose = () => {
+    (async () => {
+      try {
+        await changeIssueStatus(issueId);
+      } catch (e) {
+        console.log(e);
+      }
+    })();
+
+    setIssueCloseInfo({ isClose: !issueCloseInfo.isClose, issueId: issueId });
+  };
 
   const postHandler = ({ issueId, params }) => {
     (async () => {
@@ -115,7 +128,7 @@ const IssueDetailPage = ({
               <CommentViewBox owner createdAt={detailIssue.createdAt} content={detailIssue.content} author={detailIssue.author} />
             )}
             <CommentList />
-            <CommentInputBox postHandler={postHandler} />
+            <CommentInputBox postHandler={postHandler} changeIssueOpenClose={changeIssueOpenClose} issueCloseInfo={issueCloseInfo} />
           </CommentViewBoxWrapper>
           <FilterVerticalList />
         </Content>

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -9,16 +9,7 @@ import Header from "@Header/Header";
 import CommentViewBox from "@CommentViewBox/CommentViewBox";
 import { getDetailIssue, changeIssueStatus, postComment, putComment, deleteComment } from "@Modules/issue";
 
-const IssueDetailPage = ({
-  getDetailIssue,
-  detailIssue,
-  loadingDetailIssue,
-  postComment,
-  putComment,
-  deleteComment,
-  changeIssueStatus,
-  statusCode,
-}) => {
+const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, postComment, putComment, deleteComment, changeIssueStatus }) => {
   const { issueId } = useParams();
   const [editCommentInfo, setEditCommentInfo] = useState({ isEdit: false, editComment: null });
   const [issueCloseInfo, setIssueCloseInfo] = useState({ isClose: false, issueId: null });

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -96,14 +96,13 @@ const IssueDetailPage = ({
   );
 
   useEffect(() => {
-    const fn = async () => {
+    (async () => {
       try {
         await getDetailIssue(issueId);
       } catch (e) {
         console.log(e);
       }
-    };
-    fn();
+    })();
   }, []);
 
   return (

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -7,9 +7,18 @@ import FilterVerticalList from "@FilterButton/FilterVerticalList";
 import CommentInputBox from "@InputBox/CommentInputBox/CommentInputBox";
 import Header from "@Header/Header";
 import CommentViewBox from "@CommentViewBox/CommentViewBox";
-import { getDetailIssue, postComment, putComment, deleteComment } from "@Modules/issue";
+import { getDetailIssue, changeIssueStatus, postComment, putComment, deleteComment } from "@Modules/issue";
 
-const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, postComment, putComment, deleteComment }) => {
+const IssueDetailPage = ({
+  getDetailIssue,
+  detailIssue,
+  loadingDetailIssue,
+  postComment,
+  putComment,
+  deleteComment,
+  changeIssueStatus,
+  statusCode,
+}) => {
   const { issueId } = useParams();
   const [editCommentInfo, setEditCommentInfo] = useState({ isEdit: false, editComment: null });
 
@@ -140,10 +149,13 @@ const CommentViewBoxWrapper = styled.div`
 export default connect(
   ({ issue, loading }) => ({
     detailIssue: issue.detailIssue,
+    statusCode: issue.statusCode,
     loadingDetailIssue: loading["issue/GET_DETAIL_ISSUE"],
+    loadingStatusCode: loading["issue/CHANGE_ISSUE_STATUS_SUCCESS"],
   }),
   {
     getDetailIssue,
+    changeIssueStatus,
     postComment,
     putComment,
     deleteComment,

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -79,32 +79,30 @@ const IssueDetailPage = ({
 
   const CommentList = () => (
     <>
-      {!loadingDetailIssue &&
-        detailIssue &&
-        detailIssue.comments.map((comment) => {
-          const {
-            comment: {
-              id: { commentId },
-              createdAt,
-              content,
-            },
-            user,
-          } = comment;
+      {detailIssue.comments.map((comment) => {
+        const {
+          comment: {
+            id: { commentId },
+            createdAt,
+            content,
+          },
+          user,
+        } = comment;
 
-          return checkEditCommentInfo(commentId) ? (
-            <CommentInputBox key={commentId} commentId={commentId} editContent={content} author={user} onPass={editCommentHandler} />
-          ) : (
-            <CommentViewBox
-              key={commentId}
-              commentId={commentId}
-              createdAt={createdAt}
-              content={content}
-              author={user}
-              editClickHandler={editClickHandler}
-              deleteHandler={deleteHandler}
-            />
-          );
-        })}
+        return checkEditCommentInfo(commentId) ? (
+          <CommentInputBox key={commentId} commentId={commentId} editContent={content} author={user} onPass={editCommentHandler} />
+        ) : (
+          <CommentViewBox
+            key={commentId}
+            commentId={commentId}
+            createdAt={createdAt}
+            content={content}
+            author={user}
+            editClickHandler={editClickHandler}
+            deleteHandler={deleteHandler}
+          />
+        );
+      })}
     </>
   );
 
@@ -125,10 +123,12 @@ const IssueDetailPage = ({
         <Content>
           <CommentViewBoxWrapper>
             {!loadingDetailIssue && detailIssue && (
-              <CommentViewBox owner createdAt={detailIssue.createdAt} content={detailIssue.content} author={detailIssue.author} />
+              <>
+                <CommentViewBox owner createdAt={detailIssue.createdAt} content={detailIssue.content} author={detailIssue.author} />
+                <CommentList />
+                <CommentInputBox postHandler={postHandler} changeIssueOpenClose={changeIssueOpenClose} issueCloseInfo={issueCloseInfo} />
+              </>
             )}
-            <CommentList />
-            <CommentInputBox postHandler={postHandler} changeIssueOpenClose={changeIssueOpenClose} issueCloseInfo={issueCloseInfo} />
           </CommentViewBoxWrapper>
           <FilterVerticalList />
         </Content>


### PR DESCRIPTION
### 구현한 내용

- Issue 개폐 액션 connect로 추가
- 이슈 개폐 상태에 따라 버튼 다르게 보이도록 랜더 분기처리
- 처음 open/close 상태는 서버에서 받아온 데이터로 보여지도록 처리

![2020-07-14 21 36 44](https://user-images.githubusercontent.com/30427711/87426504-3773b280-c61a-11ea-9ea5-2c50ad57b70b.gif)
![2020-07-14 21 39 09](https://user-images.githubusercontent.com/30427711/87426660-81f52f00-c61a-11ea-9b89-d54e4019f59c.gif)

### 고민거리

- 현재 구현한 내용으로는 이슈가 개폐되어도 reload되지 않아 눈에 띄지 않는데 `window.location.reload()`를 통해 리프레시시켜주는게 맞는 것인지 고민입니다.
- 예외처리를 전반적으로 제대로 못 한 것 같아 예외처리에 대한 고민을 해서 추후 리팩토링으로 반영할 수 있도록 해야겠습니다.

Close #115 