### PR TITLE
[FE] 이슈 제목 수정

### DIFF
--- a/FE/src/components/InputBox/PersonalInputBox.jsx
+++ b/FE/src/components/InputBox/PersonalInputBox.jsx
@@ -40,7 +40,7 @@ const PersonalInputBox = ({ type, errorMsg, isRandom, title, widthSize, value, b
             isIssueTitle={isIssueTitle}
           />
         )}
-        <MessageBox children={errorMsg} fontSize="sm" color="red" />
+        {errorMsg && <MessageBox children={errorMsg} fontSize="sm" color="red" />}
       </Wrap>
     </>
   );

--- a/FE/src/components/InputBox/PersonalInputBox.jsx
+++ b/FE/src/components/InputBox/PersonalInputBox.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 import Text from "@Style/Text";
 
-const PersonalInputBox = ({ type, errorMsg, isRandom, title, widthSize, value, backgroundColor, placeholder, onChange, maxLength }) => {
+const PersonalInputBox = ({ type, errorMsg, isRandom, title, widthSize, value, backgroundColor, placeholder, onChange, maxLength, isIssueTitle }) => {
   return (
     <>
       <Wrap>
@@ -27,6 +27,7 @@ const PersonalInputBox = ({ type, errorMsg, isRandom, title, widthSize, value, b
             placeholder={placeholder}
             onChange={onChange}
             maxLength={maxLength}
+            isIssueTitle={isIssueTitle}
           />
         ) : (
           <InputBox
@@ -36,6 +37,7 @@ const PersonalInputBox = ({ type, errorMsg, isRandom, title, widthSize, value, b
             placeholder={placeholder}
             onChange={onChange}
             maxLength={maxLength}
+            isIssueTitle={isIssueTitle}
           />
         )}
         <MessageBox children={errorMsg} fontSize="sm" color="red" />
@@ -53,7 +55,7 @@ const Wrap = styled.div`
 
 const InputBox = styled.input`
   border: none;
-  margin: 5px 0;
+  margin: ${(props) => (props.isIssueTitle ? "" : "5px 0")};
   height: 40px;
   padding: 10px;
   border-radius: 5px;

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -11,6 +11,7 @@ export const postIssue = (params) =>
     method: "post",
     credentials: true,
   });
+export const patchIssueTitle = ({ issueId, params }) => axios.patch(`${API_URL.issue}${issueId}/titles`, params);
 export const postComment = ({ issueId, params }) => axios.post(`${API_URL.issue}${issueId}/comments`, params);
 export const putComment = ({ issueId, commentId, params }) => axios.put(`${API_URL.issue}${issueId}/comments/${commentId}`, params);
 export const deleteComment = ({ issueId, commentId }) => axios.delete(`${API_URL.issue}${issueId}/comments/${commentId}`);

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -14,6 +14,8 @@ const CHANGE_ISSUE_STATUS_SUCCESS = "issue/CHANGE_ISSUE_STATUS_SUCCESS";
 const POST_ISSUE = "issue/POST_ISSUE";
 const POST_ISSUE_SUCCESS = "issue/POST_ISSUE_SUCCESS";
 
+const PATCH_ISSUE_TITLE = "issue/PATCH_ISSUE_TITLE";
+
 const POST_COMMENT = "issue/POST_COMMENT";
 
 const PUT_COMMENT = "issue/PUT_COMMENT";
@@ -25,6 +27,7 @@ export const getIssue = createRequestThunk(GET_ISSUE, api.getIssue);
 export const getDetailIssue = createRequestThunk(GET_DETAIL_ISSUE, api.getDetailIssue);
 export const postIssue = createRequestThunk(POST_ISSUE, api.postIssue);
 export const changeIssueStatus = createRequestThunk(CHANGE_ISSUE_STATUS, api.changeIssueStatus);
+export const patchIssueTitle = createRequestThunk(PATCH_ISSUE_TITLE, api.patchIssueTitle);
 export const postComment = createRequestThunk(POST_COMMENT, api.postComment);
 export const putComment = createRequestThunk(PUT_COMMENT, api.putComment);
 export const deleteComment = createRequestThunk(DELETE_COMMENT, api.deleteComment);

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -3,13 +3,23 @@ import styled from "styled-components";
 import { useParams } from "react-router-dom";
 import { connect } from "react-redux";
 
+import IssueDetailTitle from "@IssueDetailPage/IssueDetailTitle/IssueDetailTitle";
 import FilterVerticalList from "@FilterButton/FilterVerticalList";
 import CommentInputBox from "@InputBox/CommentInputBox/CommentInputBox";
 import Header from "@Header/Header";
 import CommentViewBox from "@CommentViewBox/CommentViewBox";
-import { getDetailIssue, changeIssueStatus, postComment, putComment, deleteComment } from "@Modules/issue";
+import { getDetailIssue, changeIssueStatus, patchIssueTitle, postComment, putComment, deleteComment } from "@Modules/issue";
 
-const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, postComment, putComment, deleteComment, changeIssueStatus }) => {
+const IssueDetailPage = ({
+  getDetailIssue,
+  detailIssue,
+  loadingDetailIssue,
+  patchIssueTitle,
+  postComment,
+  putComment,
+  deleteComment,
+  changeIssueStatus,
+}) => {
   const { issueId } = useParams();
   const [editCommentInfo, setEditCommentInfo] = useState({ isEdit: false, editComment: null });
   const [issueCloseInfo, setIssueCloseInfo] = useState({ isClose: false, issueId: null });
@@ -161,6 +171,7 @@ export default connect(
   {
     getDetailIssue,
     changeIssueStatus,
+    patchIssueTitle,
     postComment,
     putComment,
     deleteComment,

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -78,6 +78,16 @@ const IssueDetailPage = ({
     })();
   };
 
+  const titleSaveHandler = ({ issueId, params }) => {
+    (async () => {
+      try {
+        await patchIssueTitle({ issueId, params });
+      } catch (e) {
+        console.log(e);
+      }
+    })();
+  };
+
   const CommentList = () => (
     <>
       {detailIssue.comments.map((comment) => {
@@ -123,18 +133,27 @@ const IssueDetailPage = ({
     <>
       <Header />
       <ContentWrapper>
-        <Content>
-          <CommentViewBoxWrapper>
-            {!loadingDetailIssue && detailIssue && (
-              <>
+        {!loadingDetailIssue && detailIssue && (
+          <>
+            <IssueDetailTitle
+              title={detailIssue.title}
+              id={detailIssue.id}
+              isOpen={detailIssue.title}
+              nickname={detailIssue.author.nickname}
+              createdAt={detailIssue.createdAt}
+              numberOfComment={detailIssue.numberOfComment}
+              titleSaveHandler={titleSaveHandler}
+            />
+            <Content>
+              <CommentViewBoxWrapper>
                 <CommentViewBox owner createdAt={detailIssue.createdAt} content={detailIssue.content} author={detailIssue.author} />
                 <CommentList />
                 <CommentInputBox postHandler={postHandler} changeIssueOpenClose={changeIssueOpenClose} issueCloseInfo={issueCloseInfo} />
-              </>
-            )}
-          </CommentViewBoxWrapper>
-          <FilterVerticalList />
-        </Content>
+              </CommentViewBoxWrapper>
+              <FilterVerticalList />
+            </Content>
+          </>
+        )}
       </ContentWrapper>
     </>
   );

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -131,7 +131,7 @@ const IssueDetailPage = ({ getDetailIssue, detailIssue, loadingDetailIssue, post
 };
 
 const ContentWrapper = styled.div`
-  display: flex;
+  display: grid;
   justify-content: center;
   margin-bottom: 50px;
 `;

--- a/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
@@ -1,0 +1,145 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { useHistory, useParams } from "react-router-dom";
+import TimeAgo from "react-timeago";
+import engStrings from "react-timeago/lib/language-strings/en";
+import buildFormatter from "react-timeago/lib/formatters/buildFormatter";
+
+import Text from "@Style/Text";
+import Badge from "@Style/Badge";
+import Button from "@Style/Button";
+
+import PersonalInputBox from "@InputBox/PersonalInputBox";
+
+const formatter = buildFormatter(engStrings);
+
+const IssueDetailTitle = ({ title, id, isOpen, nickname, createdAt, numberOfComment, titleSaveHandler }) => {
+  let history = useHistory();
+  const { issueId } = useParams();
+
+  const [isTitleEdit, setIsTitleEdit] = useState(false);
+  const [titleContent, setTitleContent] = useState(title);
+
+  const onSetIsTitleEdit = () => setIsTitleEdit(!isTitleEdit);
+
+  const onTitleContent = ({ target }) => setTitleContent(target.value);
+
+  const onTitleSave = () => {
+    const params = { title: titleContent };
+    onSetIsTitleEdit();
+    titleSaveHandler({ issueId, params });
+    window.location.reload();
+  };
+
+  const onPassCreateIssuePage = () => history.push(`/CreateIssuePage`);
+
+  return (
+    <>
+      <TitleWrapper>
+        {!isTitleEdit ? (
+          <>
+            <Title>
+              <Text fontSize="xxl" fontWeight="semiBold">
+                {title}
+              </Text>
+              <Text color="gray3" fontSize="xxl" fontWeight="semiBold">
+                &nbsp;#{id}
+              </Text>
+            </Title>
+            <ButtonWrapper>
+              <Button backgroundColor="white" color="black" fontSize="sm" bold onClick={onSetIsTitleEdit}>
+                Edit
+              </Button>
+              <Button fontSize="sm" bold style={{ marginLeft: "5px" }} onClick={onPassCreateIssuePage}>
+                New issue
+              </Button>
+            </ButtonWrapper>
+          </>
+        ) : (
+          <>
+            <Title>
+              <PersonalInputBox value={titleContent} widthSize={"600px"} isIssueTitle onChange={onTitleContent}></PersonalInputBox>
+            </Title>
+            <ButtonWrapper>
+              <Button backgroundColor="white" color="black" fontSize="sm" bold onClick={onTitleSave} disabled={titleContent ? false : true}>
+                Save
+              </Button>
+              <Button
+                fontSize="sm"
+                color="blue"
+                backgroundColor="white"
+                borderColor="white"
+                bold
+                style={{ marginLeft: "5px" }}
+                onClick={onSetIsTitleEdit}
+              >
+                Cancle
+              </Button>
+            </ButtonWrapper>
+          </>
+        )}
+      </TitleWrapper>
+      <Description>
+        {isOpen ? (
+          <Badge big style={{ marginRight: "5px" }}>
+            <OpenIcon>
+              <path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+            </OpenIcon>
+            Open
+          </Badge>
+        ) : (
+          <Badge big backgroundColor="red" style={{ marginRight: "5px" }}>
+            <CloseIssueIcon>
+              <path
+                fillRule="evenodd"
+                d="M1.5 8a6.5 6.5 0 0110.65-5.003.75.75 0 00.959-1.153 8 8 0 102.592 8.33.75.75 0 10-1.444-.407A6.5 6.5 0 011.5 8zM8 12a1 1 0 100-2 1 1 0 000 2zm0-8a.75.75 0 01.75.75v3.5a.75.75 0 11-1.5 0v-3.5A.75.75 0 018 4zm4.78 4.28l3-3a.75.75 0 00-1.06-1.06l-2.47 2.47-.97-.97a.749.749 0 10-1.06 1.06l1.5 1.5a.75.75 0 001.06 0z"
+              ></path>
+            </CloseIssueIcon>
+            Closed
+          </Badge>
+        )}
+        <Text fontWeight="bold" color="gray4">
+          {nickname}
+        </Text>
+        <Text color="gray4">
+          &nbsp;opened this issue <TimeAgo date={createdAt} formatter={formatter} /> · {numberOfComment} comments
+        </Text>
+      </Description>
+    </>
+  );
+};
+
+const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: 36px;
+  margin: 5px 0;
+`;
+const Title = styled.div``;
+const ButtonWrapper = styled.div`
+  display: flex;
+`;
+
+const Description = styled.div`
+  padding: 7px 0;
+  margin: 5px 0;
+`;
+
+const OpenIcon = styled.svg`
+  width: 16px;
+  height: 16px;
+  fill: ${({ theme }) => theme.colors.white};
+  overflow: visible;
+  margin-right: 15px;
+`;
+
+const CloseIssueIcon = styled.svg`
+  width: 16px;
+  height: 16px;
+  fill: ${({ theme }) => theme.colors.white};
+  overflow: visible;
+  margin-right: 5px;
+  padding-top: 2px;
+`;
+
+export default IssueDetailTitle;

--- a/FE/src/views/IssueListPage/Issue/Issue.jsx
+++ b/FE/src/views/IssueListPage/Issue/Issue.jsx
@@ -87,7 +87,7 @@ const Issue = ({ isAllChecked, issue, checkedItemHandler }) => {
           {issue.numberOfComment > 0 && (
             <>
               <ChatBubbleOutlineIcon style={{ fontSize: 15 }} />
-              {issue.numberOfComment}
+              &nbsp;{issue.numberOfComment}
             </>
           )}
         </CommentWrapper>


### PR DESCRIPTION
### 구현한 내용

- 이슈 제목 스타일링
- 이슈 제목 수정 기능 (new issue 버튼도 추가)
> closed 상태일 때
  <img width="871" alt="스크린샷 2020-07-15 오전 1 02 52" src="https://user-images.githubusercontent.com/45891045/87464825-b97dce80-c64e-11ea-9107-052c480e7051.png">

> edit 버튼 누를 시
  <img width="855" alt="스크린샷 2020-07-15 오전 3 53 09" src="https://user-images.githubusercontent.com/45891045/87464839-bda9ec00-c64e-11ea-8b67-e0993615c5ec.png">

### 고민거리
- 이슈 내용 수정 기능 
  - 후가 작성한 코멘트 수정할 때 사용하는 메소드들을 최대한 재사용 하려고 하는데 목요일에 같이 얘기해보고 더 진행할까요 아니면 일단 제가 조금만 수정해서 만들어볼까요?