### PR TITLE
[BE] Issue Pagination 처리

### DIFF
--- a/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
@@ -15,6 +15,8 @@ import com.codesquad.issuetracker.user.application.UserService;
 import com.codesquad.issuetracker.user.domain.User;
 import com.codesquad.issuetracker.user.domain.UserId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import javax.persistence.EntityNotFoundException;
@@ -22,8 +24,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class IssueService {
@@ -41,7 +43,8 @@ public class IssueService {
     private final MileStoneRepository mileStoneRepository;
 
     public IssueBoard findIssuesByFilter(Filter filter) {
-        List<IssueView> issues = StreamSupport.stream(issueRepository.findAll(IssuePredicate.search(filter), filter.getPageRequest()).spliterator(), false)
+        Page<Issue> pages = issueRepository.findAll(IssuePredicate.search(filter), filter.getPageRequest());
+        List<IssueView> issues = pages.stream()
                 .map(i -> IssueView.of(i,
                         userService.findById(i.getAuthorId()),
                         findMilestone(i.getMilestoneId()),
@@ -56,6 +59,7 @@ public class IssueService {
                 .numberOfMilestones(mileStoneRepository.count())
                 .numberOfOpenIssue(issueRepository.countByIsOpenTrue())
                 .numberOfClosedIssue(issueRepository.countByIsOpenFalse())
+                .numberOfPage(pages.getTotalPages())
                 .build();
     }
 

--- a/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/application/IssueService.java
@@ -41,7 +41,7 @@ public class IssueService {
     private final MileStoneRepository mileStoneRepository;
 
     public IssueBoard findIssuesByFilter(Filter filter) {
-        List<IssueView> issues = StreamSupport.stream(issueRepository.findAll(IssuePredicate.search(filter)).spliterator(), false)
+        List<IssueView> issues = StreamSupport.stream(issueRepository.findAll(IssuePredicate.search(filter), filter.getPageRequest()).spliterator(), false)
                 .map(i -> IssueView.of(i,
                         userService.findById(i.getAuthorId()),
                         findMilestone(i.getMilestoneId()),

--- a/BE/src/main/java/com/codesquad/issuetracker/issue/domain/Filter.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/domain/Filter.java
@@ -4,12 +4,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.domain.PageRequest;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @ToString
 public class Filter {
+
+    private static final int PAGE_SIZE = 5;
 
     private Boolean isOpen = true;
 
@@ -22,4 +25,14 @@ public class Filter {
     private Long assignee;
 
     private SortBy sort;
+
+    private int page;
+
+    public void setPage(int page) {
+        this.page = page <= 0 ? 0 : page - 1;
+    }
+
+    public PageRequest getPageRequest() {
+        return PageRequest.of(page, PAGE_SIZE);
+    }
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/issue/domain/IssueBoard.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/domain/IssueBoard.java
@@ -20,4 +20,6 @@ public class IssueBoard {
     private long numberOfOpenIssue;
 
     private long numberOfClosedIssue;
+
+    private long numberOfPage;
 }

--- a/BE/src/main/java/com/codesquad/issuetracker/issue/domain/IssueRepository.java
+++ b/BE/src/main/java/com/codesquad/issuetracker/issue/domain/IssueRepository.java
@@ -4,12 +4,12 @@ import com.codesquad.issuetracker.label.domain.LabelId;
 import com.codesquad.issuetracker.milestone.domain.MilestoneId;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface IssueRepository extends CrudRepository<Issue, IssueId>, QuerydslPredicateExecutor<Issue> {
+public interface IssueRepository extends PagingAndSortingRepository<Issue, IssueId>, QuerydslPredicateExecutor<Issue> {
 
     Issue findFirstByOrderByIdDesc();
 


### PR DESCRIPTION
### 구현한 내용

Closed #145 

- JPA의 `PagingAndSortingRepository`를 이용하여 페이징 처리 구현했습니다.
- `/issues` GET 요청 시, 요청하고자 하는 페이지 넘버를 Query Parameter의 `page`로 요청해야 합니다.
- `/issues` GET 응답에 현재 조건에 부합하는 페이지의 개수를 포함시켰습니다.