### PR TITLE
[FE] 이슈 open/close 상태관리 + 리팩토링

### DIFF
--- a/FE/src/components/FilterButton/FilterButton.jsx
+++ b/FE/src/components/FilterButton/FilterButton.jsx
@@ -78,7 +78,6 @@ const FilterButton = ({ filter, title, data, initialData = [], saveAssignees, sa
     if (anchorEl) anchorEl.focus();
     if (title !== "Milestone") setValue(pendingValue);
     setAnchorEl(null);
-    console.log(pendingValue);
 
     if (!issueId) {
       dispatch(

--- a/FE/src/components/FilterButton/FilterButton.jsx
+++ b/FE/src/components/FilterButton/FilterButton.jsx
@@ -101,7 +101,7 @@ const FilterButton = ({ filter, title, data, initialData = [], saveAssignees, sa
   };
 
   useEffect(() => {
-    if (title === "Milestone") saveMilestoneHandler({ milestoneId: pendingValue.length ? pendingValue[0].id : null });
+    if (title === "Milestone" && issueId) saveMilestoneHandler({ milestoneId: pendingValue.length ? pendingValue[0].id : null });
   }, [pendingValue, value]);
 
   return (

--- a/FE/src/components/FilterButton/FilterVerticalList.jsx
+++ b/FE/src/components/FilterButton/FilterVerticalList.jsx
@@ -1,24 +1,22 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
 import { connect } from "react-redux";
+import { useSelector } from "react-redux";
 
 import FilterButton from "@FilterButton/FilterButton";
 import { getUser } from "@Modules/user";
 import { getLabel } from "@Modules/label";
 import { getMilestone } from "@Modules/milestone";
 
-const FilterVerticalList = ({
-  users,
-  labels,
-  milestones,
-  getUser,
-  getLabel,
-  getMilestone,
-  loadingUser,
-  loadingLabel,
-  loadingMilestone,
-  optionData,
-}) => {
+const FilterVerticalList = ({ users, labels, milestones, getUser, getLabel, getMilestone, loadingUser, loadingLabel, loadingMilestone }) => {
+  const optionData = useSelector(({ issue: { detailIssue } }) => {
+    return {
+      assignees: detailIssue.assignees,
+      labels: detailIssue.labels,
+      milestone: detailIssue.milestone,
+    };
+  });
+
   const assigneeList = () => {
     return [...users].map((user) => {
       return { id: user.id.userId, name: user.nickname, color: "#fff", img: user.avatar_url, description: "" };

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -63,8 +63,7 @@ const CommentInputBox = ({
   const editClickHandler = () => editCommentHandler({ issueId, commentId, params: editParams });
 
   const onComment = () => {
-    const params = { content: rawContent };
-    postHandler({ issueId, params });
+    postHandler({ issueId, params: editParams });
     window.location.reload();
   };
 

--- a/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/CommentInputBox.jsx
@@ -21,7 +21,6 @@ const CommentInputBox = ({
   commentId,
   editContent,
   author,
-  issueCloseInfo,
 }) => {
   const { issueId } = useParams();
   const [isRawOpen, setIsRawOpen] = useState(true);
@@ -41,8 +40,6 @@ const CommentInputBox = ({
   const rawOpen = () => setIsRawOpen(true);
 
   const markdownOpen = () => setIsRawOpen(false);
-
-  const checkIssueClose = () => issueCloseInfo.isClose && issueCloseInfo.issueId === issueId;
 
   const submitParams = () => {
     return {
@@ -101,12 +98,7 @@ const CommentInputBox = ({
                 cancelClickHandler={cancelClickHandler}
               />
             ) : (
-              <SwitchButton
-                rawContent={rawContent}
-                checkIssueClose={checkIssueClose}
-                changeIssueClickHandler={changeIssueClickHandler}
-                onComment={onComment}
-              />
+              <SwitchButton rawContent={rawContent} changeIssueClickHandler={changeIssueClickHandler} onComment={onComment} />
             )}
           </ButtonWrap>
         </CommentGroup>

--- a/FE/src/components/InputBox/CommentInputBox/SwitchButton/SwitchButton.jsx
+++ b/FE/src/components/InputBox/CommentInputBox/SwitchButton/SwitchButton.jsx
@@ -1,15 +1,16 @@
 import React from "react";
 import styled from "styled-components";
+import { useSelector } from "react-redux";
 
 import Button from "@Style/Button";
 
-const SwitchButton = ({ rawContent, checkIssueClose, changeIssueClickHandler, onComment }) => {
+const SwitchButton = ({ rawContent, changeIssueClickHandler, onComment }) => {
+  const isOpen = useSelector(({ issue }) => issue.detailIssue.isOpen);
+
   return (
     <>
       <Button backgroundColor="white" color="black" style={{ marginRight: "5px" }} onClick={changeIssueClickHandler}>
-        {checkIssueClose() ? (
-          "Reopen issue"
-        ) : (
+        {isOpen ? (
           <>
             <CloseIssueIcon>
               <path
@@ -19,6 +20,8 @@ const SwitchButton = ({ rawContent, checkIssueClose, changeIssueClickHandler, on
             </CloseIssueIcon>
             Close issue
           </>
+        ) : (
+          "Reopen issue"
         )}
       </Button>
       <Button onClick={onComment} disabled={!rawContent}>

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -120,7 +120,7 @@ const IssueDetailPage = ({
                 />
                 <CommentInputBox postHandler={postHandler} changeIssueOpenClose={changeIssueOpenClose} />
               </CommentViewBoxWrapper>
-              <FilterVerticalList optionData={{ assignees: detailIssue.assignees, labels: detailIssue.labels, milestone: detailIssue.milestone }} />
+              <FilterVerticalList />
             </Content>
           </>
         )}

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -23,7 +23,6 @@ const IssueDetailPage = ({
 }) => {
   const { issueId } = useParams();
   const [editCommentInfo, setEditCommentInfo] = useState({ isEdit: false, editComment: null });
-  const [issueCloseInfo, setIssueCloseInfo] = useState({ isClose: false, issueId: null });
 
   const checkEditCommentInfo = (commentId) => editCommentInfo.isEdit && editCommentInfo.editComment === commentId;
 
@@ -36,7 +35,6 @@ const IssueDetailPage = ({
       }
     })();
 
-    setIssueCloseInfo({ isClose: !issueCloseInfo.isClose, issueId });
   };
 
   const postHandler = ({ issueId, params }) => {
@@ -99,8 +97,6 @@ const IssueDetailPage = ({
         console.log(e);
       }
     })();
-
-    if (detailIssue) setIssueCloseInfo({ isClose: detailIssue.isOpen, issueId });
   }, []);
 
   return (
@@ -129,7 +125,7 @@ const IssueDetailPage = ({
                   cancelClickHandler={cancelClickHandler}
                   deleteHandler={deleteHandler}
                 />
-                <CommentInputBox postHandler={postHandler} changeIssueOpenClose={changeIssueOpenClose} issueCloseInfo={issueCloseInfo} />
+                <CommentInputBox postHandler={postHandler} changeIssueOpenClose={changeIssueOpenClose} />
               </CommentViewBoxWrapper>
               <FilterVerticalList optionData={{ assignees: detailIssue.assignees, labels: detailIssue.labels, milestone: detailIssue.milestone }} />
             </Content>

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -35,6 +35,7 @@ const IssueDetailPage = ({
       }
     })();
 
+    window.location.reload();
   };
 
   const postHandler = ({ issueId, params }) => {

--- a/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailPage.jsx
@@ -106,15 +106,7 @@ const IssueDetailPage = ({
       <ContentWrapper>
         {!loadingDetailIssue && detailIssue && (
           <>
-            <IssueDetailTitle
-              title={detailIssue.title}
-              id={detailIssue.id}
-              isOpen={detailIssue.title}
-              nickname={detailIssue.author.nickname}
-              createdAt={detailIssue.createdAt}
-              numberOfComment={detailIssue.numberOfComment}
-              titleSaveHandler={titleSaveHandler}
-            />
+            <IssueDetailTitle titleSaveHandler={titleSaveHandler} />
             <Content>
               <CommentViewBoxWrapper>
                 <CommentViewBox owner createdAt={detailIssue.createdAt} content={detailIssue.content} author={detailIssue.author} />

--- a/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
@@ -43,7 +43,7 @@ const IssueDetailTitle = ({ title, id, isOpen, nickname, createdAt, numberOfComm
                 {title}
               </Text>
               <Text color="gray3" fontSize="xxl" fontWeight="semiBold">
-                &nbsp;#{id}
+                &nbsp;#{issueId}
               </Text>
             </Title>
             <ButtonWrapper>

--- a/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { useHistory, useParams } from "react-router-dom";
+import { useSelector } from "react-redux";
 import TimeAgo from "react-timeago";
 import engStrings from "react-timeago/lib/language-strings/en";
 import buildFormatter from "react-timeago/lib/formatters/buildFormatter";
@@ -13,9 +14,10 @@ import PersonalInputBox from "@InputBox/PersonalInputBox";
 
 const formatter = buildFormatter(engStrings);
 
-const IssueDetailTitle = ({ title, id, isOpen, nickname, createdAt, numberOfComment, titleSaveHandler }) => {
+const IssueDetailTitle = ({ titleSaveHandler }) => {
   let history = useHistory();
   const { issueId } = useParams();
+  const { title, isOpen, createdAt, numberOfComment, author } = useSelector(({ issue }) => issue.detailIssue);
 
   const [isTitleEdit, setIsTitleEdit] = useState(false);
   const [titleContent, setTitleContent] = useState(title);
@@ -99,7 +101,7 @@ const IssueDetailTitle = ({ title, id, isOpen, nickname, createdAt, numberOfComm
           </Badge>
         )}
         <Text fontWeight="bold" color="gray4">
-          {nickname}
+          {author.nickname}
         </Text>
         <Text color="gray4">
           &nbsp;opened this issue <TimeAgo date={createdAt} formatter={formatter} /> · {numberOfComment} comments

--- a/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
+++ b/FE/src/views/IssueDetailPage/IssueDetailTitle/IssueDetailTitle.jsx
@@ -73,7 +73,7 @@ const IssueDetailTitle = ({ title, id, isOpen, nickname, createdAt, numberOfComm
                 style={{ marginLeft: "5px" }}
                 onClick={onSetIsTitleEdit}
               >
-                Cancle
+                Cancel
               </Button>
             </ButtonWrapper>
           </>


### PR DESCRIPTION
### 구현한 내용

#### 이슈 open/close 상태관리
- 기존 로컬에서 하던 상태관리를 reload로 데이터를 바꿔 주도록 변경

#### 리팩토링
- FilterVerticalList, IssueDetailTitle에서 전해 주던 store 데이터 관련 props를 삭제하고 useSelector에서 쓸 수 있도록 리팩토링
- CommentViewBox는 코멘트가 모두 다르게 나오려면 props를 전달해 줘야만 해서 기존 상태 유지

Close #149 