### PR TITLE
[FE] Pagination

### DIFF
--- a/FE/public/index.html
+++ b/FE/public/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <base href="/" />
     <meta charset="UTF-8" name="format-detection" content="telephone=no" />
     <meta name="viewport" content="width=device-width, user-scalable=no" />
-    <meta name="description" content="React + Typescript + SSR + Code-splitting" />
+    <meta name="description" content="Issue Tracker Service" />
     <meta name="google" content="notranslate" />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <title>Issue Tracker</title>

--- a/FE/src/components/FilterButton/FilterVerticalList.jsx
+++ b/FE/src/components/FilterButton/FilterVerticalList.jsx
@@ -10,11 +10,17 @@ import { getMilestone } from "@Modules/milestone";
 
 const FilterVerticalList = ({ users, labels, milestones, getUser, getLabel, getMilestone, loadingUser, loadingLabel, loadingMilestone }) => {
   const optionData = useSelector(({ issue: { detailIssue } }) => {
-    return {
-      assignees: detailIssue.assignees,
-      labels: detailIssue.labels,
-      milestone: detailIssue.milestone,
-    };
+    return detailIssue
+      ? {
+          assignees: detailIssue.assignees,
+          labels: detailIssue.labels,
+          milestone: detailIssue.milestone,
+        }
+      : {
+          assignees: [],
+          labels: [],
+          milestone: null,
+        };
   });
 
   const assigneeList = () => {

--- a/FE/src/lib/api.js
+++ b/FE/src/lib/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { API_URL } from "@Constants/url";
 
-export const getIssue = () => axios.get(API_URL.issue);
+export const getIssue = (params) => axios.get(API_URL.issue, { params });
 export const getDetailIssue = (issueId) => axios.get(`${API_URL.issue}${issueId}`);
 export const changeIssueStatus = (issueId) => axios.patch(`${API_URL.issue}/${issueId}`);
 export const postIssue = (params) =>

--- a/FE/src/modules/issue.js
+++ b/FE/src/modules/issue.js
@@ -34,6 +34,7 @@ export const deleteComment = createRequestThunk(DELETE_COMMENT, api.deleteCommen
 
 const initialState = {
   issues: null,
+  issueInfo: null,
   detailIssue: null,
   statusCode: null,
 };
@@ -43,6 +44,13 @@ const issue = handleActions(
     [GET_ISSUE_SUCCESS]: (state, action) => ({
       ...state,
       issues: action.payload.data.issues,
+      issueInfo: {
+        numberOfLabels: action.payload.data.numberOfLabels,
+        numberOfMilestones: action.payload.data.numberOfMilestones,
+        numberOfOpenIssue: action.payload.data.numberOfOpenIssue,
+        numberOfClosedIssue: action.payload.data.numberOfClosedIssue,
+        numberOfPage: action.payload.data.numberOfPage,
+      },
     }),
     [GET_DETAIL_ISSUE_SUCCESS]: (state, action) => ({
       ...state,

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -8,6 +8,7 @@ import Button from "@Style/Button";
 
 import Issue from "@IssueListPage/Issue/Issue";
 import IssueListHeader from "@IssueListPage/IssueListHeader/IssueListHeader";
+import Pagination from "@IssueListPage/Pagination/Pagination";
 import NavigationButton from "@NavigationButton/NavigationButton";
 import FilterButton from "@FilterButton/FilterButton";
 import Header from "@Header/Header";
@@ -86,6 +87,7 @@ const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
         </NavBar>
       </NavBarWrap>
       <Table tableHeader={<IssueListHeader allCheckedHandler={allCheckedHandler} />} tableList={<IssueList />} />
+      {isGetIssues() && <Pagination numberOfPage={issueInfo.numberOfPage}></Pagination>}
     </>
   );
 };

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import SearchIcon from "@material-ui/icons/Search";
 import { connect, useDispatch } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 
 import Button from "@Style/Button";
 
@@ -15,9 +15,12 @@ import Table from "@Table/Table";
 import { getIssue } from "@Modules/issue";
 import { resetOption } from "@Modules/option";
 
-const IssueListPage = ({ getIssue, issues, loadingIssue }) => {
 const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
   let history = useHistory();
+  let location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const currentPage = searchParams.get("page");
+
   const dispatch = useDispatch();
 
   const [checkedItems, setCheckedItems] = useState(new Set());

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -16,6 +16,7 @@ import { getIssue } from "@Modules/issue";
 import { resetOption } from "@Modules/option";
 
 const IssueListPage = ({ getIssue, issues, loadingIssue }) => {
+const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
   let history = useHistory();
   const dispatch = useDispatch();
 
@@ -160,6 +161,7 @@ const SearchInputIcon = styled(SearchIcon)`
 export default connect(
   ({ issue, loading }) => ({
     issues: issue.issues,
+    issueInfo: issue.issueInfo,
     loadingIssue: loading["issue/GET_ISSUE"],
   }),
   {

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -49,9 +49,7 @@ const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
   const IssueList = () => (
     <>
       {isGetIssues() &&
-        issues
-          .reverse()
-          .map((issue) => <Issue isAllChecked={isAllChecked} key={issue.id} issue={issue} checkedItemHandler={checkedItemHandler}></Issue>)}
+        issues.map((issue) => <Issue isAllChecked={isAllChecked} key={issue.id} issue={issue} checkedItemHandler={checkedItemHandler}></Issue>)}
     </>
   );
 

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -85,7 +85,7 @@ const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
         </NavBar>
       </NavBarWrap>
       <Table tableHeader={<IssueListHeader allCheckedHandler={allCheckedHandler} />} tableList={<IssueList />} />
-      {isGetIssues() && <Pagination numberOfPage={issueInfo.numberOfPage} currentPage={currentPage ? parseInt(currentPage) : null}></Pagination>}
+      {isGetIssues() && <Pagination numberOfPage={issueInfo.numberOfPage} currentPage={parseInt(currentPage)}></Pagination>}
     </>
   );
 };

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -57,7 +57,7 @@ const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
   useEffect(() => {
     const fn = async () => {
       try {
-        await getIssue();
+        await getIssue({ page: currentPage });
       } catch (e) {
         console.log(e);
       }
@@ -65,7 +65,7 @@ const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
     fn();
 
     dispatch(resetOption());
-  }, []);
+  }, [currentPage]);
 
   return (
     <>

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -87,7 +87,7 @@ const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
         </NavBar>
       </NavBarWrap>
       <Table tableHeader={<IssueListHeader allCheckedHandler={allCheckedHandler} />} tableList={<IssueList />} />
-      {isGetIssues() && <Pagination numberOfPage={issueInfo.numberOfPage}></Pagination>}
+      {isGetIssues() && <Pagination numberOfPage={issueInfo.numberOfPage} currentPage={currentPage}></Pagination>}
     </>
   );
 };

--- a/FE/src/views/IssueListPage/IssueListPage.jsx
+++ b/FE/src/views/IssueListPage/IssueListPage.jsx
@@ -87,7 +87,7 @@ const IssueListPage = ({ getIssue, issues, issueInfo, loadingIssue }) => {
         </NavBar>
       </NavBarWrap>
       <Table tableHeader={<IssueListHeader allCheckedHandler={allCheckedHandler} />} tableList={<IssueList />} />
-      {isGetIssues() && <Pagination numberOfPage={issueInfo.numberOfPage} currentPage={currentPage}></Pagination>}
+      {isGetIssues() && <Pagination numberOfPage={issueInfo.numberOfPage} currentPage={currentPage ? parseInt(currentPage) : null}></Pagination>}
     </>
   );
 };

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -73,6 +73,15 @@ const PageButton = styled.button`
   padding: 5px 12px;
   border: none;
   background: none;
+  &.default {
+    color: ${({ theme }) => theme.colors.black};
+    background-color: ${({ theme }) => theme.colors.white};
+  }
+  &.focus {
+    color: ${({ theme }) => theme.colors.white};
+    background-color: ${({ theme }) => theme.colors.blue};
+    border-radius: 6px;
+  }
 `;
 
 const NextPageButton = styled(Button)`

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -10,8 +10,8 @@ const Pagination = ({ numberOfPage, currentPage = 1 }) => {
   let history = useHistory();
 
   const pageNumbers = Array.from(Array(numberOfPage), (_, i) => i + 1);
-  const prevPage = Number(currentPage) - 1;
-  const nextPage = Number(currentPage) + 1;
+  const prevPage = currentPage - 1;
+  const nextPage = currentPage + 1;
 
   const isPrevDisabled = currentPage <= 1;
   const isNextDisabled = currentPage >= numberOfPage;

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -13,6 +13,9 @@ const Pagination = ({ numberOfPage, currentPage }) => {
   const prevPage = Number(currentPage) - 1;
   const nextPage = Number(currentPage) + 1;
 
+  const isPrevDisabled = currentPage <= 1;
+  const isNextDisabled = currentPage >= numberOfPage;
+
   const onPass = (number) =>
     history.push({
       pathname: "/IssueListPage",
@@ -23,7 +26,7 @@ const Pagination = ({ numberOfPage, currentPage }) => {
     <>
       <Wrapper>
         <PageLists>
-          <PrevPageButton onClick={() => onPass(prevPage)}>
+          <PrevPageButton onClick={() => onPass(prevPage)} disabled={isPrevDisabled}>
             <ArrowBackIosIcon />
           </PrevPageButton>
           {pageNumbers.map((number) => (
@@ -31,7 +34,7 @@ const Pagination = ({ numberOfPage, currentPage }) => {
               {number}
             </PageButton>
           ))}
-          <NextPageButton onClick={() => onPass(nextPage)}>
+          <NextPageButton onClick={() => onPass(nextPage)} disabled={isNextDisabled}>
             <ArrowForwardIosIcon />
           </NextPageButton>
         </PageLists>

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -6,8 +6,9 @@ import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos";
 
 import Button from "@Style/Button";
 
-const Pagination = ({ numberOfPage, currentPage = 1 }) => {
+const Pagination = ({ numberOfPage, currentPage }) => {
   let history = useHistory();
+  currentPage = currentPage ? currentPage : 1;
 
   const pageNumbers = Array.from(Array(numberOfPage), (_, i) => i + 1);
   const prevPage = currentPage - 1;

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -6,7 +6,7 @@ import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos";
 
 import Button from "@Style/Button";
 
-const Pagination = ({ numberOfPage, currentPage }) => {
+const Pagination = ({ numberOfPage, currentPage = 1 }) => {
   let history = useHistory();
 
   const pageNumbers = Array.from(Array(numberOfPage), (_, i) => i + 1);

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import styled from "styled-components";
+import { useHistory } from "react-router-dom";
+
+const Pagination = ({ numberOfPage }) => {
+  let history = useHistory();
+
+  const pageNumbers = Array.from(Array(numberOfPage), (_, i) => i + 1);
+
+  const onPass = (number) =>
+    history.push({
+      pathname: "/IssueListPage",
+      search: `?page=${number}`,
+    });
+
+  return (
+    <>
+      <Wrapper>
+        <PageLists>
+          {pageNumbers.map((number) => (
+            <PageButton key={number} onClick={() => onPass(number)}>
+              {number}
+            </PageButton>
+          ))}
+        </PageLists>
+      </Wrapper>
+    </>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PageLists = styled.ul`
+  display: flex;
+`;
+
+const PageButton = styled.button`
+  cursor: pointer;
+  font-size: 2rem;
+  color: ${(props) => props.theme.uiColorOrange};
+  margin: 0 0.3rem;
+  padding: 0;
+  border: none;
+  background: none;
+`;
+
+export default Pagination;

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -13,6 +13,11 @@ const Pagination = ({ numberOfPage, currentPage = 1 }) => {
   const prevPage = currentPage - 1;
   const nextPage = currentPage + 1;
 
+  const isManyPage = numberOfPage >= 10;
+  const isFrontPage = currentPage < 7;
+  const isMiddlePage = currentPage >= 7 && currentPage <= numberOfPage - 6;
+  const isEndPage = currentPage > numberOfPage - 6;
+
   const isPrevDisabled = currentPage <= 1;
   const isNextDisabled = currentPage >= numberOfPage;
 

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -2,10 +2,12 @@ import React from "react";
 import styled from "styled-components";
 import { useHistory } from "react-router-dom";
 
-const Pagination = ({ numberOfPage }) => {
+const Pagination = ({ numberOfPage, currentPage }) => {
   let history = useHistory();
 
   const pageNumbers = Array.from(Array(numberOfPage), (_, i) => i + 1);
+  const prevPage = Number(currentPage) - 1;
+  const nextPage = Number(currentPage) + 1;
 
   const onPass = (number) =>
     history.push({

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -28,6 +28,12 @@ const Pagination = ({ numberOfPage, currentPage }) => {
       search: `?page=${number}`,
     });
 
+  const page = (number) => (
+    <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+      {number}
+    </PageButton>
+  );
+
   return (
     <>
       <Wrapper>
@@ -35,61 +41,28 @@ const Pagination = ({ numberOfPage, currentPage }) => {
           <PrevPageButton onClick={() => onPass(prevPage)} disabled={isPrevDisabled} backgroundColor="white" color="blue">
             <ArrowBackIosIcon />
           </PrevPageButton>
-          {!isManyPage &&
-            pageNumbers.map((number) => (
-              <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                {number}
-              </PageButton>
-            ))}
+          {!isManyPage && pageNumbers.map((number) => page(number))}
           {isManyPage && isFrontPage && (
             <>
-              {pageNumbers.slice(0, currentPage + 2).map((number) => (
-                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                  {number}
-                </PageButton>
-              ))}
+              {pageNumbers.slice(0, currentPage + 2).map((number) => page(number))}
               ...
-              {pageNumbers.slice(18, numberOfPage).map((number) => (
-                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                  {number}
-                </PageButton>
-              ))}
+              {pageNumbers.slice(18, numberOfPage).map((number) => page(number))}
             </>
           )}
           {isManyPage && isMiddlePage && (
             <>
-              {pageNumbers.slice(0, 2).map((number) => (
-                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                  {number}
-                </PageButton>
-              ))}
+              {pageNumbers.slice(0, 2).map((number) => page(number))}
               ...
-              {pageNumbers.slice(currentPage - 3, currentPage + 2).map((number) => (
-                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                  {number}
-                </PageButton>
-              ))}
+              {pageNumbers.slice(currentPage - 3, currentPage + 2).map((number) => page(number))}
               ...
-              {pageNumbers.slice(18, numberOfPage).map((number) => (
-                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                  {number}
-                </PageButton>
-              ))}
+              {pageNumbers.slice(18, numberOfPage).map((number) => page(number))}
             </>
           )}
           {isManyPage && isEndPage && (
             <>
-              {pageNumbers.slice(0, 2).map((number) => (
-                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                  {number}
-                </PageButton>
-              ))}
+              {pageNumbers.slice(0, 2).map((number) => page(number))}
               ...
-              {pageNumbers.slice(currentPage - 2, numberOfPage).map((number) => (
-                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
-                  {number}
-                </PageButton>
-              ))}
+              {pageNumbers.slice(currentPage - 2, numberOfPage).map((number) => page(number))}
             </>
           )}
           <NextPageButton onClick={() => onPass(nextPage)} disabled={isNextDisabled} backgroundColor="white" color="blue">

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -34,11 +34,63 @@ const Pagination = ({ numberOfPage, currentPage = 1 }) => {
           <PrevPageButton onClick={() => onPass(prevPage)} disabled={isPrevDisabled} backgroundColor="white" color="blue">
             <ArrowBackIosIcon />
           </PrevPageButton>
-          {pageNumbers.map((number) => (
-            <PageButton key={number} onClick={() => onPass(number)}>
-              {number}
-            </PageButton>
-          ))}
+          {!isManyPage &&
+            pageNumbers.map((number) => (
+              <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                {number}
+              </PageButton>
+            ))}
+          {isManyPage && isFrontPage && (
+            <>
+              {pageNumbers.slice(0, currentPage + 2).map((number) => (
+                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                  {number}
+                </PageButton>
+              ))}
+              ...
+              {pageNumbers.slice(18, numberOfPage).map((number) => (
+                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                  {number}
+                </PageButton>
+              ))}
+            </>
+          )}
+          {isManyPage && isMiddlePage && (
+            <>
+              {pageNumbers.slice(0, 2).map((number) => (
+                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                  {number}
+                </PageButton>
+              ))}
+              ...
+              {pageNumbers.slice(currentPage - 3, currentPage + 2).map((number) => (
+                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                  {number}
+                </PageButton>
+              ))}
+              ...
+              {pageNumbers.slice(18, numberOfPage).map((number) => (
+                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                  {number}
+                </PageButton>
+              ))}
+            </>
+          )}
+          {isManyPage && isEndPage && (
+            <>
+              {pageNumbers.slice(0, 2).map((number) => (
+                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                  {number}
+                </PageButton>
+              ))}
+              ...
+              {pageNumbers.slice(currentPage - 2, numberOfPage).map((number) => (
+                <PageButton key={number} onClick={() => onPass(number)} className={currentPage === number ? "focus" : "default"}>
+                  {number}
+                </PageButton>
+              ))}
+            </>
+          )}
           <NextPageButton onClick={() => onPass(nextPage)} disabled={isNextDisabled} backgroundColor="white" color="blue">
             <ArrowForwardIosIcon />
           </NextPageButton>

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -26,7 +26,7 @@ const Pagination = ({ numberOfPage, currentPage = 1 }) => {
     <>
       <Wrapper>
         <PageLists>
-          <PrevPageButton onClick={() => onPass(prevPage)} disabled={isPrevDisabled}>
+          <PrevPageButton onClick={() => onPass(prevPage)} disabled={isPrevDisabled} backgroundColor="white" color="blue">
             <ArrowBackIosIcon />
           </PrevPageButton>
           {pageNumbers.map((number) => (
@@ -34,7 +34,7 @@ const Pagination = ({ numberOfPage, currentPage = 1 }) => {
               {number}
             </PageButton>
           ))}
-          <NextPageButton onClick={() => onPass(nextPage)} disabled={isNextDisabled}>
+          <NextPageButton onClick={() => onPass(nextPage)} disabled={isNextDisabled} backgroundColor="white" color="blue">
             <ArrowForwardIosIcon />
           </NextPageButton>
         </PageLists>

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -1,6 +1,10 @@
 import React from "react";
 import styled from "styled-components";
 import { useHistory } from "react-router-dom";
+import ArrowBackIosIcon from "@material-ui/icons/ArrowBackIos";
+import ArrowForwardIosIcon from "@material-ui/icons/ArrowForwardIos";
+
+import Button from "@Style/Button";
 
 const Pagination = ({ numberOfPage, currentPage }) => {
   let history = useHistory();
@@ -19,11 +23,17 @@ const Pagination = ({ numberOfPage, currentPage }) => {
     <>
       <Wrapper>
         <PageLists>
+          <PrevPageButton onClick={() => onPass(prevPage)}>
+            <ArrowBackIosIcon />
+          </PrevPageButton>
           {pageNumbers.map((number) => (
             <PageButton key={number} onClick={() => onPass(number)}>
               {number}
             </PageButton>
           ))}
+          <NextPageButton onClick={() => onPass(nextPage)}>
+            <ArrowForwardIosIcon />
+          </NextPageButton>
         </PageLists>
       </Wrapper>
     </>
@@ -36,8 +46,14 @@ const Wrapper = styled.div`
   align-items: center;
 `;
 
-const PageLists = styled.ul`
+const PageLists = styled.div`
   display: flex;
+`;
+
+const PrevPageButton = styled(Button)`
+  &::after {
+    content: "Previous";
+  }
 `;
 
 const PageButton = styled.button`
@@ -48,6 +64,12 @@ const PageButton = styled.button`
   padding: 0;
   border: none;
   background: none;
+`;
+
+const NextPageButton = styled(Button)`
+  &::before {
+    content: "Next";
+  }
 `;
 
 export default Pagination;

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -61,10 +61,9 @@ const PrevPageButton = styled(Button)`
 
 const PageButton = styled.button`
   cursor: pointer;
-  font-size: 2rem;
-  color: ${(props) => props.theme.uiColorOrange};
-  margin: 0 0.3rem;
-  padding: 0;
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  margin: 0 0.2rem;
+  padding: 5px 12px;
   border: none;
   background: none;
 `;

--- a/FE/src/views/IssueListPage/Pagination/Pagination.jsx
+++ b/FE/src/views/IssueListPage/Pagination/Pagination.jsx
@@ -54,6 +54,8 @@ const PageLists = styled.div`
 `;
 
 const PrevPageButton = styled(Button)`
+  height: 2rem;
+  border: none;
   &::after {
     content: "Previous";
   }
@@ -69,6 +71,8 @@ const PageButton = styled.button`
 `;
 
 const NextPageButton = styled(Button)`
+  height: 2rem;
+  border: none;
   &::before {
     content: "Next";
   }


### PR DESCRIPTION
### 구현한 내용

#### page params 추가시켜 받아오도록 하기

- `history.push`할 때 **pathname**과 **search**를 객체 형태로 작성

```js
history.push({
      pathname: "/IssueListPage",
      search: `?page=${number}`,
})
```

#### UI
- prev 클릭시 1페이지 앞으로 포커스
- next 클릭 시 1페이지 뒤로 포커스
- 처음에 데이터를 통해 몇 페이지까지 표시될지 만들기
- **현재 page와 전체 페이지 개수에 따라 다르게 랜더되도록 진행**

```js
  const isManyPage = numberOfPage >= 10;
  const isFrontPage = currentPage < 7;
  const isMiddlePage = currentPage >= 7 && currentPage <= numberOfPage - 6;
  const isEndPage = currentPage > numberOfPage - 6;
```

<img width="643" alt="Screen Shot 2020-07-21 at 19 59 58" src="https://user-images.githubusercontent.com/30427711/88051219-39e28900-cb93-11ea-922d-c64df78da802.png">  
<img width="630" alt="Screen Shot 2020-07-21 at 20 00 06" src="https://user-images.githubusercontent.com/30427711/88051254-44048780-cb93-11ea-8ae1-7572712e58e3.png">
<img width="623" alt="Screen Shot 2020-07-21 at 20 00 15" src="https://user-images.githubusercontent.com/30427711/88051350-6c8c8180-cb93-11ea-80ab-2c03923c8539.png">


- **더이상 뒤에 페이지가 없으면 클릭할 수 없게 disabled 처리**

<img width="540" alt="Screen Shot 2020-07-21 at 19 59 48" src="https://user-images.githubusercontent.com/30427711/88051198-33541180-cb93-11ea-8c37-3b709a6904f7.png">  
<img width="488" alt="Screen Shot 2020-07-21 at 20 00 20" src="https://user-images.githubusercontent.com/30427711/88051288-51217680-cb93-11ea-9112-dff1a2f10253.png">

Close #150 


---

### 참고 

https://medium.com/@loshy244110/react-%ED%8E%98%EC%9D%B4%EC%A7%80-%EB%84%A4%EC%9D%B4%EC%85%98-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-9c645c5046cd